### PR TITLE
Add stage-2 preset to babel

### DIFF
--- a/web-app/.babelrc
+++ b/web-app/.babelrc
@@ -1,4 +1,4 @@
 {
-    "presets": ["env", "react"],
-    "plugins": ["transform-class-properties"]
+  "presets": ["env", "react", "stage-2"],
+  "plugins": ["transform-class-properties"]
 }

--- a/web-app/.babelrc
+++ b/web-app/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["env", "react", "stage-2"],
-  "plugins": ["transform-class-properties"]
+  "presets": ["env", "react", "stage-2"]
 }

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1",
     "css-loader": "^0.28.11",
     "eslint": "^4.19.1",
     "eslint-plugin-babel": "^5.1.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -15,7 +15,6 @@
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.4",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",


### PR DESCRIPTION
Adds the ability to use stage 2 features like the spread operator.  Also removes the plugin `transform-class-properties` as this is included in the stage 2 preset.