### PR TITLE
Persist whether or not the nav drawer is open between page reloads

### DIFF
--- a/web-app/src/hoc/Layout/container.js
+++ b/web-app/src/hoc/Layout/container.js
@@ -10,7 +10,7 @@ export default Wrapped =>
     constructor(props) {
       super(props);
       this.state = {
-        drawerOpen: localStorage.getItem('navDrawerOpen') == 'true' || false,
+        drawerOpen: localStorage.getItem('navDrawerOpen') == 'true',
         menuItems: [
           {
             name: 'Profile',
@@ -59,8 +59,9 @@ export default Wrapped =>
     }
 
     toggleDrawer = () => {
-      this.setState({ drawerOpen: !this.state.drawerOpen });
-      localStorage.setItem('navDrawerOpen', !this.state.drawerOpen);
+      this.setState({ drawerOpen: !this.state.drawerOpen }, () => {
+        localStorage.setItem('navDrawerOpen', this.state.drawerOpen);
+      });
     };
 
     render() {

--- a/web-app/src/hoc/Layout/container.js
+++ b/web-app/src/hoc/Layout/container.js
@@ -10,6 +10,7 @@ export default Wrapped =>
     constructor(props) {
       super(props);
       this.state = {
+        drawerOpen: localStorage.getItem('navDrawerOpen') == 'true' || false,
         menuItems: [
           {
             name: 'Profile',
@@ -57,7 +58,18 @@ export default Wrapped =>
       };
     }
 
+    toggleDrawer = () => {
+      this.setState({ drawerOpen: !this.state.drawerOpen });
+      localStorage.setItem('navDrawerOpen', !this.state.drawerOpen);
+    };
+
     render() {
-      return <Wrapped {...this.props} {...this.state} />;
+      return (
+        <Wrapped
+          {...this.props}
+          {...this.state}
+          toggleDrawer={this.toggleDrawer}
+        />
+      );
     }
   };

--- a/web-app/src/hoc/Layout/index.js
+++ b/web-app/src/hoc/Layout/index.js
@@ -6,10 +6,16 @@ import { LayoutContainer, Input } from './styled';
 
 export const Layout = props => {
   let drawer = null;
+
   if (props.isAuthenticated) {
     drawer = (
       <Fragment>
-        <Input type="checkbox" id="toggle-drawer" />
+        <Input
+          type="checkbox"
+          id="toggle-drawer"
+          onChange={props.toggleDrawer}
+          checked={props.drawerOpen}
+        />
         <NavMenu
           isAuthenticated={props.isAuthenticated}
           userDetails={props.userDetails}
@@ -36,5 +42,7 @@ Layout.propTypes = {
   history: PT.object,
   isAuthenticated: PT.bool,
   children: PT.node,
+  drawerOpen: PT.bool,
+  toggleDrawer: PT.func,
 };
 export default container(Layout);

--- a/web-app/src/hoc/Layout/index.js
+++ b/web-app/src/hoc/Layout/index.js
@@ -6,21 +6,28 @@ import { LayoutContainer, Input } from './styled';
 
 export const Layout = props => {
   let drawer = null;
+  const {
+    isAuthenticated,
+    toggleDrawer,
+    drawerOpen,
+    children,
+    history,
+    menuItems,
+  } = props;
 
-  if (props.isAuthenticated) {
+  if (isAuthenticated) {
     drawer = (
       <Fragment>
         <Input
           type="checkbox"
           id="toggle-drawer"
-          onChange={props.toggleDrawer}
-          checked={props.drawerOpen}
+          onChange={toggleDrawer}
+          checked={drawerOpen}
         />
         <NavMenu
-          isAuthenticated={props.isAuthenticated}
-          userDetails={props.userDetails}
-          history={props.history}
-          menuItems={props.menuItems}
+          isAuthenticated={isAuthenticated}
+          history={history}
+          menuItems={menuItems}
         />
       </Fragment>
     );
@@ -29,20 +36,19 @@ export const Layout = props => {
   return (
     <Fragment>
       {drawer}
-      <LayoutContainer history={props.history.location.pathname}>
-        {props.children}
+      <LayoutContainer history={history.location.pathname}>
+        {children}
       </LayoutContainer>
     </Fragment>
   );
 };
 
 Layout.propTypes = {
-  menuItems: PT.array,
-  userDetails: PT.object,
-  history: PT.object,
-  isAuthenticated: PT.bool,
-  children: PT.node,
-  drawerOpen: PT.bool,
-  toggleDrawer: PT.func,
+  menuItems: PT.array.isRequired,
+  history: PT.object.isRequired,
+  isAuthenticated: PT.bool.isRequired,
+  children: PT.node.isRequired,
+  drawerOpen: PT.bool.isRequired,
+  toggleDrawer: PT.func.isRequired,
 };
 export default container(Layout);


### PR DESCRIPTION
- The drawer now uses localStorage to persist if it's open or not between page reloads.