### PR TITLE
Fix for updating holidays

### DIFF
--- a/BackEnd/src/main/java/com/unosquare/admin_core/back_end/configuration/AppConfig.java
+++ b/BackEnd/src/main/java/com/unosquare/admin_core/back_end/configuration/AppConfig.java
@@ -5,6 +5,7 @@ import com.unosquare.admin_core.back_end.dto.DateDTO;
 import com.unosquare.admin_core.back_end.dto.EmployeeDto;
 import com.unosquare.admin_core.back_end.dto.HolidayDto;
 import com.unosquare.admin_core.back_end.entity.*;
+import javafx.beans.property.Property;
 import org.modelmapper.AbstractConverter;
 import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
@@ -44,10 +45,24 @@ public class AppConfig {
             @Override
             protected HolidayDto convert(Holiday source) {
                 HolidayDto ret = new HolidayDto(source.getHolidayId(), source.getStartDate(), source.getEndDate(),
-                        modelMapper.map(source.getEmployee(), EmployeeDto.class),
-                        source.getHolidayStatus().getHolidayStatusId(), source.isHalfDay());
+                        source.getEmployee().getEmployeeId(), source.getHolidayStatus().getHolidayStatusId(), source.isHalfDay());
 
                 return ret;
+            }
+        };
+
+        PropertyMap<HolidayDto, Holiday> holidayEntityMapping = new PropertyMap<HolidayDto, Holiday>() {
+            @Override
+            protected void configure() {
+                skip().setDateCreated(null);
+                skip().getHolidayStatus().setDescription(source.getHolidayStatusDescription());
+                map().setLastModified(LocalDate.now());
+                map().setHalfDay(source.isHalfDay());
+                map().setEndDate(source.getEndDate());
+                map().setEmployee(new Employee(source.getEmployeeId()));
+                map().setHolidayId(source.getHolidayId());
+                map().setHolidayStatus(new HolidayStatus(source.getHolidayStatusId()));
+                map().setStartDate(source.getStartDate());
             }
         };
 
@@ -75,6 +90,7 @@ public class AppConfig {
         modelMapper.addConverter(holidayConverter);
         modelMapper.addMappings(employeeMapping);
         modelMapper.addConverter(holidayDtoConvert);
+        modelMapper.addMappings(holidayEntityMapping);
 
         return modelMapper;
     }

--- a/BackEnd/src/main/java/com/unosquare/admin_core/back_end/controller/HolidayController.java
+++ b/BackEnd/src/main/java/com/unosquare/admin_core/back_end/controller/HolidayController.java
@@ -100,7 +100,7 @@ public class HolidayController {
     @PutMapping(value = "/", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public void updateHoliday(@RequestBody HolidayDto holiday) {
-        holidayService.save(holiday.getEmployee().getEmployeeId(), modelMapper.map(holiday, Holiday.class));
+        holidayService.save(holiday.getEmployeeId(), modelMapper.map(holiday, Holiday.class));
     }
 
     @PutMapping(value = "/updateMultiple", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/BackEnd/src/main/java/com/unosquare/admin_core/back_end/dto/HolidayDto.java
+++ b/BackEnd/src/main/java/com/unosquare/admin_core/back_end/dto/HolidayDto.java
@@ -14,7 +14,7 @@ public class HolidayDto {
     private LocalDate startDate;
     private LocalDate endDate;
 
-    private EmployeeDto employee;
+    private int employeeId;
 
     private int holidayStatusId;
     private String holidayStatusDescription;
@@ -28,11 +28,11 @@ public class HolidayDto {
 
     }
 
-    public HolidayDto(int holidayId, LocalDate startDate, LocalDate endDate, EmployeeDto employee, int holidayStatusId, boolean isHalfDay) {
+    public HolidayDto(int holidayId, LocalDate startDate, LocalDate endDate, int employeeId, int holidayStatusId, boolean isHalfDay) {
         this.holidayId = holidayId;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.employee = employee;
+        this.employeeId = employeeId;
         this.holidayStatusId = (short) holidayStatusId;
         this.lastModified = LocalDate.now();
         this.dateCreated = LocalDate.now();
@@ -40,10 +40,10 @@ public class HolidayDto {
         this.isHalfDay = isHalfDay;
     }
 
-    public HolidayDto(LocalDate startDate, LocalDate endDate, EmployeeDto employee, int holidayStatusId, boolean isHalfDay) {
+    public HolidayDto(LocalDate startDate, LocalDate endDate, int employeeId, int holidayStatusId, boolean isHalfDay) {
         this.startDate = startDate;
         this.endDate = endDate;
-        this.employee = employee;
+        this.employeeId = employeeId;
         this.holidayStatusId = (short) holidayStatusId;
         this.lastModified = LocalDate.now();
         this.dateCreated = LocalDate.now();


### PR DESCRIPTION
Fixed call for updating holidays. HolidayDto requires only EmployeeId now, not full Employee object, and HolidayStatusId only need be passed. HolidayStatusDescription kept for now in case required for future calls.now in case required for future calls. Mappings updated to reflect changes.