### PR TITLE
Feat/configure booking nav

### DIFF
--- a/NativeApp/src/components/Booking/View/index.js
+++ b/NativeApp/src/components/Booking/View/index.js
@@ -1,30 +1,31 @@
 import React from 'react';
-import { Text, Button } from 'react-native';
+import {
+  View,
+  Text,
+  Button,
+  StyleSheet,
+} from 'react-native';
 import { PropTypes as PT } from 'prop-types';
 import moment from 'moment';
-import { ModalWrapper, CustomDatePickerIOS } from '../../Common';
+import { CustomDatePickerIOS } from '../../Common';
 
-const BookingModal = (props) => {
+const BookingView = (props) => {
   const {
-    showModal,
-    closeModal,
     startDate,
-    endDate,
-    submitRequest,
     changeStartDate,
+    endDate,
     changeEndDate,
+    submitRequest,
   } = props;
 
   const formatDate = date => moment(date).toDate();
 
   return (
-    <ModalWrapper
-      showModal={showModal}
-      closeModal={closeModal}
-    >
+    <View style={styles.container}>
       <Text>
         Starting
         {'\n'}
+        {startDate}
       </Text>
       <CustomDatePickerIOS
         chosenDate={formatDate(startDate)}
@@ -39,18 +40,25 @@ const BookingModal = (props) => {
         minimumDate={formatDate(startDate)}
       />
       <Button onPress={submitRequest} title="Request Holiday" />
-    </ModalWrapper>
+    </View>
   );
 };
 
-BookingModal.propTypes = {
-  showModal: PT.bool.isRequired,
-  closeModal: PT.func.isRequired,
-  submitRequest: PT.func.isRequired,
+BookingView.propTypes = {
   startDate: PT.string.isRequired,
   endDate: PT.string.isRequired,
   changeStartDate: PT.func.isRequired,
   changeEndDate: PT.func.isRequired,
+  submitRequest: PT.func.isRequired,
 };
 
-export default BookingModal;
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    paddingTop: 50,
+    backgroundColor: '#fff',
+  },
+});
+
+export default BookingView;

--- a/NativeApp/src/components/Booking/container.js
+++ b/NativeApp/src/components/Booking/container.js
@@ -1,0 +1,101 @@
+import React, { Component } from 'react';
+import { Alert } from 'react-native';
+import { PropTypes as PT } from 'prop-types';
+import moment from 'moment';
+import { userProfile } from '../../utilities/currentUser';
+import { requestHolidays } from '../../services/holidayService';
+
+
+export default Container => class extends Component {
+  static propTypes = {
+    navigation: PT.shape({
+      navigate: PT.fun,
+    }).isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      booking: {
+        startDate: '',
+        endDate: '',
+        halfDay: false,
+      },
+      user: {},
+    };
+  }
+
+  componentDidMount() {
+    const { navigation } = this.props;
+    const chosenDate = navigation.getParam('date', '');
+
+    userProfile()
+      .then(user => this.setState({ user }));
+
+    this.setState({
+      booking: {
+        startDate: chosenDate,
+        endDate: chosenDate,
+      },
+    });
+  }
+
+  changeStartDate = (date) => {
+    const formatDate = moment(date).format('YYYY-MM-DD');
+    this.setState(prevState => ({
+      booking: {
+        ...prevState.booking,
+        startDate: formatDate,
+      },
+    }));
+  }
+
+  changeEndDate = (endDate) => {
+    const formatEndDate = moment(endDate).format('YYYY-MM-DD');
+    this.setState(prevState => ({
+      booking: {
+        ...prevState.booking,
+        endDate: formatEndDate,
+      },
+    }));
+  }
+
+  submitRequest = () => {
+    const { booking, user } = this.state;
+    const { navigation } = this.props;
+
+    const request = {
+      dates: [
+        {
+          endDate: booking.endDate,
+          halfDay: false,
+          startDate: booking.startDate,
+        },
+      ],
+      employeeId: user.employeeId,
+    };
+
+    requestHolidays(request)
+      .then(() => {
+        navigation.pop();
+      })
+      .catch(e => Alert.alert(
+        'Could not request holidays',
+        e.message,
+      ));
+  }
+
+  render() {
+    const { booking } = this.state;
+
+    return (
+      <Container
+        startDate={booking.startDate}
+        endDate={booking.endDate}
+        submitRequest={this.submitRequest}
+        changeStartDate={this.changeStartDate}
+        changeEndDate={this.changeEndDate}
+      />
+    );
+  }
+};

--- a/NativeApp/src/components/Booking/index.js
+++ b/NativeApp/src/components/Booking/index.js
@@ -1,0 +1,4 @@
+import container from './container';
+import BookingView from './View';
+
+export default container(BookingView);

--- a/NativeApp/src/components/Home/View/index.js
+++ b/NativeApp/src/components/Home/View/index.js
@@ -2,33 +2,16 @@ import React from 'react';
 import { PropTypes as PT } from 'prop-types';
 import { View, Button, StyleSheet } from 'react-native';
 import { CalendarList } from 'react-native-calendars';
-import BookingModal from '../BookingModal';
 
 const HomeView = (props) => {
   const {
     handleLogout,
     takenHolidays,
     onDayPress,
-    showModal,
-    closeModal,
-    startDate,
-    endDate,
-    submitRequest,
-    changeStartDate,
-    changeEndDate,
   } = props;
 
   return (
     <View style={styles.container}>
-      <BookingModal
-        showModal={showModal}
-        closeModal={closeModal}
-        startDate={startDate}
-        endDate={endDate}
-        submitRequest={submitRequest}
-        changeStartDate={changeStartDate}
-        changeEndDate={changeEndDate}
-      />
       <Button
         onPress={handleLogout}
         title="Logout"
@@ -54,13 +37,6 @@ HomeView.propTypes = {
     color: PT.string,
   }).isRequired,
   onDayPress: PT.func.isRequired,
-  showModal: PT.bool.isRequired,
-  closeModal: PT.func.isRequired,
-  startDate: PT.string.isRequired,
-  endDate: PT.string.isRequired,
-  changeStartDate: PT.func.isRequired,
-  changeEndDate: PT.func.isRequired,
-  submitRequest: PT.func.isRequired,
 };
 
 const styles = StyleSheet.create({

--- a/NativeApp/src/components/Home/container.js
+++ b/NativeApp/src/components/Home/container.js
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
-import { Alert } from 'react-native';
 import { PropTypes as PT } from 'prop-types';
 import moment from 'moment';
 import { userLogout, userProfile } from '../../utilities/currentUser';
 import { getTakenHolidays } from '../../utilities/holidays';
-import { requestHolidays } from '../../services/holidayService';
 
 export default Container => class extends Component {
     static propTypes = {
@@ -32,68 +30,32 @@ export default Container => class extends Component {
     }
 
     componentDidMount() {
-      getTakenHolidays()
-        .then(data => this.setState({ takenHolidays: this.formatDate(data) }));
+      const { navigation } = this.props;
 
-      userProfile()
-        .then(user => this.setState({ user }));
+      this.sub = navigation.addListener('didFocus', () => {
+        getTakenHolidays()
+          .then(data => this.setState({ takenHolidays: this.formatDate(data) }));
+
+        userProfile()
+          .then(user => this.setState({ user }));
+      });
+    }
+
+    componentWillUnmount() {
+      this.sub.remove();
     }
 
     onDayPress = (day) => {
+      const { navigation } = this.props;
       if (day) {
         this.setState({
-          showModal: true,
           booking: {
             startDate: day.dateString,
             endDate: day.dateString,
           },
         });
+        navigation.push('Booking', { date: day.dateString });
       }
-    }
-
-    submitRequest = () => {
-      const { booking, user } = this.state;
-      const request = {
-        dates: [
-          {
-            endDate: booking.endDate,
-            halfDay: false,
-            startDate: booking.startDate,
-          },
-        ],
-        employeeId: user.employeeId,
-      };
-
-      requestHolidays(request)
-        .then(() => {
-          getTakenHolidays()
-            .then(data => this.setState({ takenHolidays: this.formatDate(data) }));
-          this.closeModal();
-        })
-        .catch(e => Alert.alert(
-          'Could not request holidays',
-          e.message,
-        ));
-    }
-
-    changeStartDate = (date) => {
-      const formatDate = moment(date).format('YYYY-MM-DD');
-      this.setState(prevState => ({
-        booking: {
-          ...prevState.booking,
-          startDate: formatDate,
-        },
-      }));
-    }
-
-    changeEndDate = (endDate) => {
-      const formatEndDate = moment(endDate).format('YYYY-MM-DD');
-      this.setState(prevState => ({
-        booking: {
-          ...prevState.booking,
-          endDate: formatEndDate,
-        },
-      }));
     }
 
     closeModal = () => {
@@ -149,24 +111,13 @@ export default Container => class extends Component {
     }
 
     render() {
-      const {
-        takenHolidays,
-        showModal,
-        booking,
-      } = this.state;
+      const { takenHolidays } = this.state;
 
       return (
         <Container
           handleLogout={this.handleLogout}
           takenHolidays={takenHolidays}
           onDayPress={this.onDayPress}
-          showModal={showModal}
-          closeModal={this.closeModal}
-          startDate={booking.startDate}
-          endDate={booking.endDate}
-          submitRequest={this.submitRequest}
-          changeStartDate={this.changeStartDate}
-          changeEndDate={this.changeEndDate}
         />
       );
     }

--- a/NativeApp/src/components/Home/container.js
+++ b/NativeApp/src/components/Home/container.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
 import moment from 'moment';
-import { userLogout, userProfile } from '../../utilities/currentUser';
+import { userLogout } from '../../utilities/currentUser';
 import { getTakenHolidays } from '../../utilities/holidays';
 
 export default Container => class extends Component {
@@ -20,7 +20,6 @@ export default Container => class extends Component {
       this.state = {
         takenHolidays: {},
         showModal: false,
-        user: null,
         booking: {
           startDate: '',
           endDate: '',
@@ -35,9 +34,6 @@ export default Container => class extends Component {
       this.sub = navigation.addListener('didFocus', () => {
         getTakenHolidays()
           .then(data => this.setState({ takenHolidays: this.formatDate(data) }));
-
-        userProfile()
-          .then(user => this.setState({ user }));
       });
     }
 

--- a/NativeApp/src/screens/Booking.js
+++ b/NativeApp/src/screens/Booking.js
@@ -16,8 +16,6 @@ export default class BookingScreen extends Component {
   render() {
     const { navigation } = this.props;
 
-    return (
-      <Booking navigation={navigation} />
-    );
+    return <Booking navigation={navigation} />;
   }
 }

--- a/NativeApp/src/screens/Booking.js
+++ b/NativeApp/src/screens/Booking.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
-import Home from '../components/Home';
+import Booking from '../components/Booking';
 
-export default class HomeScreen extends Component {
+export default class BookingScreen extends Component {
   static navigationOptions = {
-    header: null,
+    title: 'Request Holidays',
   }
 
   static propTypes = {
@@ -17,7 +17,7 @@ export default class HomeScreen extends Component {
     const { navigation } = this.props;
 
     return (
-      <Home navigation={navigation} />
+      <Booking navigation={navigation} />
     );
   }
 }

--- a/NativeApp/src/screens/Home.js
+++ b/NativeApp/src/screens/Home.js
@@ -1,10 +1,13 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import Home from '../components/Home';
 
 export default class HomeScreen extends Component {
   static navigationOptions = {
     title: 'Home',
+    tabBarIcon: <Icon name="home" size={25} color="#fff" />,
+    tabBarColor: '#14967C',
   }
 
   static propTypes = {

--- a/NativeApp/src/screens/Home.js
+++ b/NativeApp/src/screens/Home.js
@@ -16,8 +16,6 @@ export default class HomeScreen extends Component {
   render() {
     const { navigation } = this.props;
 
-    return (
-      <Home navigation={navigation} />
-    );
+    return <Home navigation={navigation} />;
   }
 }

--- a/NativeApp/src/screens/Login.js
+++ b/NativeApp/src/screens/Login.js
@@ -15,8 +15,6 @@ export default class LoginScreen extends Component {
 
   render() {
     const { navigation } = this.props;
-    return (
-      <Login navigation={navigation} />
-    );
+    return <Login navigation={navigation} />;
   }
 }

--- a/NativeApp/src/screens/Team.js
+++ b/NativeApp/src/screens/Team.js
@@ -1,10 +1,13 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import Team from '../components/Team';
 
 export default class TeamScreen extends Component {
   static navigationOptions = {
     title: 'Team',
+    tabBarIcon: <Icon name="group" size={25} color="#fff" />,
+    tabBarColor: '#2ABDBD',
   }
 
   static propTypes = {

--- a/NativeApp/src/screens/Team.js
+++ b/NativeApp/src/screens/Team.js
@@ -18,8 +18,6 @@ export default class TeamScreen extends Component {
 
   render() {
     const { navigation } = this.props;
-    return (
-      <Team navigation={navigation} />
-    );
+    return <Team navigation={navigation} />;
   }
 }

--- a/NativeApp/src/screens/User.js
+++ b/NativeApp/src/screens/User.js
@@ -1,10 +1,13 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import User from '../components/User';
 
 export default class UserScreen extends Component {
   static navigationOptions = {
     title: 'User Info',
+    tabBarIcon: <Icon name="user" size={25} color="#fff" />,
+    tabBarColor: '#FF545E',
   }
 
   static propTypes = {

--- a/NativeApp/src/screens/User.js
+++ b/NativeApp/src/screens/User.js
@@ -18,8 +18,6 @@ export default class UserScreen extends Component {
 
   render() {
     const { navigation } = this.props;
-    return (
-      <User navigation={navigation} />
-    );
+    return <User navigation={navigation} />;
   }
 }

--- a/NativeApp/src/screens/index.js
+++ b/NativeApp/src/screens/index.js
@@ -3,3 +3,4 @@ export { default as Login } from './Login';
 export { default as Boot } from './Boot';
 export { default as Team } from './Team';
 export { default as User } from './User';
+export { default as Booking } from './Booking';

--- a/NativeApp/src/utilities/navigationConfig.js
+++ b/NativeApp/src/utilities/navigationConfig.js
@@ -1,31 +1,49 @@
-import {
-  createStackNavigator,
-  createSwitchNavigator,
-} from 'react-navigation';
-import {
-  createMaterialBottomTabNavigator,
-} from 'react-navigation-material-bottom-tabs';
-
+import React from 'react';
+import { createStackNavigator, createSwitchNavigator } from 'react-navigation';
+import { createMaterialBottomTabNavigator } from 'react-navigation-material-bottom-tabs';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import {
   Home,
   Login,
   Boot,
   Team,
   User,
+  Booking,
 } from '../screens';
+
+const HomeStack = createStackNavigator(
+  {
+    Home: { screen: Home },
+    Booking: { screen: Booking },
+  },
+  {
+    initialRouteName: 'Home',
+  }
+);
+
+HomeStack.navigationOptions = () => {
+  const tabBarIcon = (<Icon name="home" size={25} color="#fff" />);
+  const tabBarColor = '#14967C';
+
+  return {
+    tabBarIcon,
+    tabBarColor,
+  };
+};
 
 const AppStack = createMaterialBottomTabNavigator(
   {
-    Home: { screen: Home },
+    HomeStack: { screen: HomeStack },
     User: { screen: User },
     Team: { screen: Team },
   }, {
-    initialRouteName: 'Home',
+    initialRouteName: 'HomeStack',
     activeTintColor: '#f0edf6',
     inactiveTintColor: '#3e2465',
     shifting: true,
   }
 );
+
 const AuthStack = createStackNavigator({ Login });
 
 const RootNavigator = createSwitchNavigator(

--- a/NativeApp/src/utilities/navigationConfig.js
+++ b/NativeApp/src/utilities/navigationConfig.js
@@ -23,7 +23,7 @@ const AppStack = createMaterialBottomTabNavigator(
     initialRouteName: 'Home',
     activeTintColor: '#f0edf6',
     inactiveTintColor: '#3e2465',
-    barStyle: { backgroundColor: '#1abc9c' },
+    shifting: true,
   }
 );
 const AuthStack = createStackNavigator({ Login });


### PR DESCRIPTION
Kinda went down a rabbit hole with this one. Originally was meant to set the date picker up nicely but then came across an issue. Currently the requesting holidays was built using a modal, the date picker will also be a modal. A modal on top of a modal will only cause problems in the future, plus is genuinely   bad practise.

So in the PR:
- I've separated the booking component into it's own screen.
- Update the nav config for new home stack navigator. Which includes the Home and Booking screen.
- UI updates to Tab bar.
- New `didFocus` listener added to home container. Updates the calendar screen every time it's focused.