### PR TITLE
Fix table sorting and filtering

### DIFF
--- a/web-app/src/components/AllClients/index.jsx
+++ b/web-app/src/components/AllClients/index.jsx
@@ -30,6 +30,7 @@ export const AllClients = ({
         clients={clients}
         columns={['clientName']}
         onRowClick={data => selectClient(data)}
+        pageSize={20}
       />
     </Fragment>
   );

--- a/web-app/src/components/AllEmployees/index.js
+++ b/web-app/src/components/AllEmployees/index.js
@@ -17,6 +17,7 @@ const AllEmployees = ({ history, users, selectUser, selectedUser }) => {
         users={users}
         columns={['fullName', 'email', 'role', 'location']}
         onRowClick={employee => selectUser(employee)}
+        pageSize={20}
       />
     </Fragment>
   );

--- a/web-app/src/components/AllHolidays/index.jsx
+++ b/web-app/src/components/AllHolidays/index.jsx
@@ -15,6 +15,7 @@ export const AllHolidays = ({
       <h2>All Holidays</h2>
       <HolidayList
         holidays={holidays}
+        pageSize={20}
         columns={[
           'status',
           'employee',

--- a/web-app/src/components/ClientList/index.jsx
+++ b/web-app/src/components/ClientList/index.jsx
@@ -11,14 +11,14 @@ const buildColumns = columns => {
   return formattedColumns;
 };
 
-const renderTable = (clients, columns, onRowClick) => {
+const renderTable = (clients, columns, onRowClick, pageSize) => {
   const formattedColumns = buildColumns(columns);
   return (
     <ReactTable
       filterable
       data={clients}
       columns={formattedColumns}
-      defaultPageSize={10}
+      defaultPageSize={pageSize}
       className="-striped -highlight"
       getTrProps={(state, rowInfo) => {
         return {
@@ -33,11 +33,11 @@ const renderTable = (clients, columns, onRowClick) => {
 };
 
 export const ClientList = props => {
-  const { clients, columns, onRowClick } = props;
+  const { clients, columns, onRowClick, pageSize } = props;
   return !clients || clients.length === 0 ? (
     <p>There are no clients to show</p>
   ) : (
-    renderTable(clients, columns, onRowClick)
+    renderTable(clients, columns, onRowClick, pageSize)
   );
 };
 
@@ -45,10 +45,12 @@ ClientList.propTypes = {
   clients: PT.array,
   columns: PT.array.isRequired,
   onRowClick: PT.func,
+  pageSize: PT.number,
 };
 
 ClientList.defaultProps = {
   onRowClick: () => {},
+  pageSize: 10,
 };
 
 export default ClientList;

--- a/web-app/src/components/ContractList/index.jsx
+++ b/web-app/src/components/ContractList/index.jsx
@@ -11,13 +11,13 @@ const buildColumns = columns => {
   return formattedColumns;
 };
 
-const renderTable = (contracts, columns, onRowClick) => {
+const renderTable = (contracts, columns, onRowClick, pageSize) => {
   const formattedColumns = buildColumns(columns);
   return (
     <ReactTable
       data={contracts}
       columns={formattedColumns}
-      defaultPageSize={10}
+      defaultPageSize={pageSize}
       className="-striped -highlight"
       getTrProps={(state, rowInfo) => {
         return {
@@ -32,11 +32,11 @@ const renderTable = (contracts, columns, onRowClick) => {
 };
 
 export const ContractList = props => {
-  const { contracts, columns, onRowClick } = props;
+  const { contracts, columns, onRowClick, pageSize } = props;
   return !contracts || contracts.length === 0 ? (
     <p>There are no contracts to show</p>
   ) : (
-    renderTable(contracts, columns, onRowClick)
+    renderTable(contracts, columns, onRowClick, pageSize)
   );
 };
 
@@ -44,10 +44,12 @@ ContractList.propTypes = {
   contracts: PT.array,
   columns: PT.array.isRequired,
   onRowClick: PT.func,
+  pageSize: PT.number,
 };
 
 ContractList.defaultProps = {
   onRowClick: () => {},
+  pageSize: 10,
 };
 
 export default ContractList;

--- a/web-app/src/components/HolidayList/TableValues.js
+++ b/web-app/src/components/HolidayList/TableValues.js
@@ -6,10 +6,9 @@ import moment from 'moment';
 const status = {
   id: 'status',
   Header: 'Status',
-  sortable: false,
-  filterable: false,
   width: 110,
-  accessor: holiday => statusText[holiday.eventStatus.eventStatusId],
+  accessor: holiday => holiday.eventStatus.eventStatusId,
+  Cell: cell => statusText[cell.row.status],
   getProps: (state, rowInfo) => {
     if (!rowInfo) return {};
     return {
@@ -19,38 +18,30 @@ const status = {
       },
     };
   },
+  filterMethod: ({ value }, { status }) =>
+    statusText[status].toLowerCase().includes(value.toLowerCase()),
 };
 
 const employee = {
   id: 'employee',
   Header: 'Employee',
   accessor: ({ employee }) => `${employee.forename} ${employee.surname}`,
-  sortMethod: (a, b) => {
-    if (a === b) {
-      return 0;
-    }
-    const aReverse = a
-      .split('')
-      .reverse()
-      .join('');
-    const bReverse = b
-      .split('')
-      .reverse()
-      .join('');
-    return aReverse > bReverse ? 1 : -1;
-  },
 };
 
 const startDate = {
   id: 'startDate',
   Header: 'Start Date',
-  accessor: holiday => holiday.start.format('Do MMM YYYY'),
+  accessor: holiday => holiday.start,
+  Cell: cell => cell.row.startDate.format('Do MMM YYYY'),
+  sortMethod: (a, b) => (a.isBefore(b) ? 1 : -1),
 };
 
 const endDate = {
   id: 'endDate',
   Header: 'End Date',
-  accessor: holiday => holiday.end.format('Do MMM YYYY'),
+  accessor: holiday => holiday.start,
+  Cell: cell => cell.row.endDate.format('Do MMM YYYY'),
+  sortMethod: (a, b) => (a.isBefore(b) ? 1 : -1),
 };
 
 const requestedDate = {

--- a/web-app/src/components/HolidayList/TableValues.js
+++ b/web-app/src/components/HolidayList/TableValues.js
@@ -34,6 +34,11 @@ const startDate = {
   accessor: holiday => holiday.start,
   Cell: cell => cell.row.startDate.format('Do MMM YYYY'),
   sortMethod: (a, b) => (a.isBefore(b) ? 1 : -1),
+  filterMethod: ({ value }, { startDate }) =>
+    startDate
+      .format('Do MMM YYYY')
+      .toLowerCase()
+      .includes(value.toLowerCase()),
 };
 
 const endDate = {
@@ -42,6 +47,11 @@ const endDate = {
   accessor: holiday => holiday.start,
   Cell: cell => cell.row.endDate.format('Do MMM YYYY'),
   sortMethod: (a, b) => (a.isBefore(b) ? 1 : -1),
+  filterMethod: ({ value }, { endDate }) =>
+    endDate
+      .format('Do MMM YYYY')
+      .toLowerCase()
+      .includes(value.toLowerCase()),
 };
 
 const requestedDate = {

--- a/web-app/src/components/HolidayList/index.jsx
+++ b/web-app/src/components/HolidayList/index.jsx
@@ -11,14 +11,14 @@ const buildColumns = columns => {
   return formattedColumns;
 };
 
-const renderTable = (holidays, columns, onRowClick) => {
+const renderTable = (holidays, columns, onRowClick, pageSize) => {
   const formattedColumns = buildColumns(columns);
   return (
     <ReactTable
       filterable
       data={holidays}
       columns={formattedColumns}
-      defaultPageSize={10}
+      defaultPageSize={pageSize}
       className="-striped -highlight"
       getTrProps={(state, rowInfo) => {
         return {
@@ -28,16 +28,22 @@ const renderTable = (holidays, columns, onRowClick) => {
           },
         };
       }}
+      defaultSorted={[
+        {
+          id: 'startDate',
+          desc: true,
+        },
+      ]}
     />
   );
 };
 
 export const HolidayList = props => {
-  const { holidays, columns, onRowClick } = props;
+  const { holidays, columns, onRowClick, pageSize } = props;
   return !holidays || holidays.length === 0 ? (
     <p>There are no holidays to show</p>
   ) : (
-    renderTable(holidays, columns, onRowClick)
+    renderTable(holidays, columns, onRowClick, pageSize)
   );
 };
 
@@ -45,10 +51,12 @@ HolidayList.propTypes = {
   holidays: PT.array.isRequired,
   columns: PT.array.isRequired,
   onRowClick: PT.func,
+  pageSize: PT.number,
 };
 
 HolidayList.defaultProps = {
   onRowClick: () => {},
+  pageSize: 10,
 };
 
 export default HolidayList;

--- a/web-app/src/components/PendingHolidays/index.jsx
+++ b/web-app/src/components/PendingHolidays/index.jsx
@@ -15,6 +15,7 @@ export const PendingHolidays = ({
       <h2>Manage Pending Holidays</h2>
       <HolidayList
         holidays={pendingHolidays}
+        pageSize={20}
         columns={[
           'status',
           'employee',

--- a/web-app/src/components/TeamList/index.jsx
+++ b/web-app/src/components/TeamList/index.jsx
@@ -11,13 +11,13 @@ const buildColumns = columns => {
   return formattedColumns;
 };
 
-const renderTable = (teams, columns, onRowClick) => {
+const renderTable = (teams, columns, onRowClick, pageSize) => {
   const formattedColumns = buildColumns(columns);
   return (
     <ReactTable
       data={teams}
       columns={formattedColumns}
-      defaultPageSize={10}
+      defaultPageSize={pageSize}
       className="-striped -highlight"
       getTrProps={(state, rowInfo) => {
         return {
@@ -32,11 +32,11 @@ const renderTable = (teams, columns, onRowClick) => {
 };
 
 export const TeamList = props => {
-  const { teams, columns, onRowClick } = props;
+  const { teams, columns, onRowClick, pageSize } = props;
   return !teams || teams.length === 0 ? (
     <p>There are no teams to show</p>
   ) : (
-    renderTable(teams, columns, onRowClick)
+    renderTable(teams, columns, onRowClick, pageSize)
   );
 };
 
@@ -44,10 +44,12 @@ TeamList.propTypes = {
   teams: PT.array,
   columns: PT.array.isRequired,
   onRowClick: PT.func,
+  pageSize: PT.number,
 };
 
 TeamList.defaultProps = {
   onRowClick: () => {},
+  pageSize: 10,
 };
 
 export default TeamList;

--- a/web-app/src/components/UserList/index.jsx
+++ b/web-app/src/components/UserList/index.jsx
@@ -12,13 +12,13 @@ const buildColumns = columns => {
   return formattedColumns;
 };
 
-const renderTable = (users, columns, onRowClick) => {
+const renderTable = (users, columns, onRowClick, pageSize) => {
   const formattedColumns = buildColumns(columns);
   return (
     <ReactTable
       data={users}
       columns={formattedColumns}
-      defaultPageSize={10}
+      defaultPageSize={pageSize}
       filterable
       className="-striped -highlight"
       defaultFilterMethod={(filter, row) =>
@@ -37,11 +37,11 @@ const renderTable = (users, columns, onRowClick) => {
 };
 
 export const UserList = props => {
-  const { users, columns, onRowClick } = props;
+  const { users, columns, onRowClick, pageSize } = props;
   return !users || users.length === 0 ? (
     <p>There are no users to show</p>
   ) : (
-    renderTable(users, columns, onRowClick)
+    renderTable(users, columns, onRowClick, pageSize)
   );
 };
 
@@ -49,10 +49,12 @@ UserList.propTypes = {
   users: PT.array,
   columns: PT.array.isRequired,
   onRowClick: PT.func,
+  pageSize: PT.number,
 };
 
 UserList.defaultProps = {
   onRowClick: () => {},
+  pageSize: 10,
 };
 
 export default container(UserList);

--- a/web-app/src/components/ViewContracts/index.jsx
+++ b/web-app/src/components/ViewContracts/index.jsx
@@ -17,7 +17,11 @@ export const ViewContracts = ({ contracts, updateContracts, history }) => {
       </CornerButton>
       <h2>View Contracts</h2>
       <SearchUserForm onSuccess={updateContracts} />
-      <ContractList contracts={contracts} columns={['startDate', 'endDate']} />
+      <ContractList
+        contracts={contracts}
+        columns={['startDate', 'endDate']}
+        pageSize={20}
+      />
     </div>
   );
 };

--- a/web-app/src/components/ViewTeams/index.jsx
+++ b/web-app/src/components/ViewTeams/index.jsx
@@ -17,7 +17,7 @@ export const ViewTeams = ({ teamSearch, teams, history }) => {
       </CornerButton>
       <h2>View Teams</h2>
       <ViewTeamsForm onChange={teamSearch} />
-      <TeamList teams={teams} columns={['teamName']} />
+      <TeamList teams={teams} columns={['teamName']} pageSize={20} />
     </div>
   );
 };


### PR DESCRIPTION
Finally got my head around how `react-table` works, so a few improvements:

**Holiday Tables**
- Can now be sorted and filtered by status.
- Dates can now be sorted properly.
- New filtering logic for dates, as the sorting broke the default for them.
- Sorting on the tables are now sorted by the earliest start date. *This means a start date is always required*

**All Tables**
- All tables now take a `pageSize` prop, which changes how many rows are shown.
- All admin pages now have a default of 20 rows.