### PR TITLE
Wrap emails with mailto links

### DIFF
--- a/web-app/src/components/HolidayModal/index.js
+++ b/web-app/src/components/HolidayModal/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PropTypes as PT } from 'prop-types';
 import container from './container';
-import { Modal, Button } from '../../components/common';
+import { Modal, Button, Email } from '../../components/common';
 import { StyleContainer, Stat, StatWrap, ButtonWrap, StatusH2 } from './styled';
 import { getEventDayAmount } from '../../utilities/dates';
 import { statusText } from '../../utilities/holidayStatus';
@@ -22,7 +22,7 @@ const HolidayModal = ({
         <div>
           <h2>Manage Holiday</h2>
           <p>
-            {forename} {surname} - {email}
+            {forename} {surname} - <Email>{email}</Email>
           </p>
         </div>
         <StatWrap>

--- a/web-app/src/components/UserModal/index.js
+++ b/web-app/src/components/UserModal/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
-import { Modal, Button } from '../../components/common';
+import { Modal, Button, Email } from '../../components/common';
 import { StyleContainer, Stat, StatWrap } from './styled';
 import { getHolidays } from '../../services/holidayService';
 import swal from 'sweetalert2';
@@ -67,7 +67,7 @@ class UserModal extends Component {
             <h2>
               {user.forename} {user.surname}
             </h2>
-            <p>{user.email}</p>
+            <Email>{user.email}</Email>
           </div>
           <StatWrap>
             <Stat>

--- a/web-app/src/components/common/Email/index.js
+++ b/web-app/src/components/common/Email/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { PropTypes as PT } from 'prop-types';
+import { StyledLink } from '../../common_styled';
+
+const Email = ({ children }) => (
+  <StyledLink href={`mailto:${children}`}>{children}</StyledLink>
+);
+
+Email.propTypes = {
+  children: PT.string,
+};
+
+export default Email;

--- a/web-app/src/components/common/index.js
+++ b/web-app/src/components/common/index.js
@@ -8,3 +8,4 @@ export { default as Input } from './Input';
 export { default as Form } from './Form';
 export { default as Steps } from './Steps';
 export { default as Table } from './Table';
+export { default as Email } from './Email';

--- a/web-app/src/components/common_styled/StyledLink.js
+++ b/web-app/src/components/common_styled/StyledLink.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export default styled.a`
+  color: ${props => props.theme.colours.unoBlue};
+  text-decoration: none;
+  :hover {
+    text-decoration: underline;
+  }
+  :active {
+    color: ${props => props.theme.colours.darkBlue};
+  }
+`;

--- a/web-app/src/components/common_styled/index.js
+++ b/web-app/src/components/common_styled/index.js
@@ -1,1 +1,2 @@
 export { default as CornerButton } from './CornerButton';
+export { default as StyledLink } from './StyledLink';

--- a/web-app/src/pages/User/index.jsx
+++ b/web-app/src/pages/User/index.jsx
@@ -10,6 +10,7 @@ import {
   faArrowLeft,
 } from '@fortawesome/fontawesome-free-solid';
 import { roleText } from '../../utilities/roles';
+import { Email } from '../../components/common';
 
 export const User = props => {
   if (!props.profileUser) return null;
@@ -30,7 +31,7 @@ export const User = props => {
         </h1>
         <p>
           <FontAwesomeIcon icon={faEnvelope} />
-          {email}
+          <Email>{email}</Email>
         </p>
         <p>
           <FontAwesomeIcon icon={faIdCard} />


### PR DESCRIPTION
Small PR.

- Created a common styled component `StyledLink` for anchor hyperlinks.
- Created `Email` component that turns child content into a `mailto` link.
- Wrapped any emails in the UI with the `Email` component.