### PR TITLE
Clean up styling in Dashboard

### DIFF
--- a/web-app/src/components/BigCalendarToolbar/index.js
+++ b/web-app/src/components/BigCalendarToolbar/index.js
@@ -18,7 +18,7 @@ const BigCalendarToolbar = props => {
   return (
     <StyleContainer>
       <div>
-        <h2>Team Holidays</h2>
+        <h2>Booking Dashboard</h2>
         <p className="date">{props.label}</p>
       </div>
       <div>

--- a/web-app/src/components/BigCalendarToolbar/styled.js
+++ b/web-app/src/components/BigCalendarToolbar/styled.js
@@ -9,7 +9,7 @@ export const StyleContainer = styled.div`
     margin: 0 0 0px 0;
   }
   p {
-    margin: 0;
+    margin: 8px 0 0 0;
     text-transform: uppercase;
     font-size: 16px;
     color: ${({ theme }) => theme.colours.darkGrey};

--- a/web-app/src/components/BookingCalendar/index.jsx
+++ b/web-app/src/components/BookingCalendar/index.jsx
@@ -24,6 +24,9 @@ export const BookingCalendar = props => {
       showMultiDayTimes
       selectable
       views={{ month: true }}
+      formats={{
+        weekdayFormat: 'dddd',
+      }}
     />
   );
 };

--- a/web-app/src/components/Legend/styled.js
+++ b/web-app/src/components/Legend/styled.js
@@ -4,6 +4,7 @@ export const StyleContainer = styled.div`
   box-sizing: border-box;
   background-color: ${props => props.theme.colours.lightgrey};
   border: 1px solid ${props => props.theme.colours.grey};
+  border-radius: 0 0 6px 6px;
   border-top: none;
   width: 100%;
   padding: 20px 10px 0 10px;
@@ -28,7 +29,6 @@ export const Column = styled.div`
     display: flex;
     align-items: flex-start;
     flex-wrap: wrap;
-    margin-bottom: 0;
   }
 
   :nth-child(1) {
@@ -73,7 +73,7 @@ export const Key = styled.div`
   color: white;
   font-size: 12px;
   font-weight: 400;
-  margin: 4px 4px 4px 0;
+  margin: 0px 4px 4px 0;
   border-radius: 3px;
   padding: 8px;
   align-self: auto;

--- a/web-app/src/components/Legend/styled.js
+++ b/web-app/src/components/Legend/styled.js
@@ -3,11 +3,10 @@ import styled from 'styled-components';
 export const StyleContainer = styled.div`
   box-sizing: border-box;
   background-color: ${props => props.theme.colours.lightgrey};
-  border: 2px solid ${props => props.theme.colours.grey};
-  border-radius: 6px;
+  border: 1px solid ${props => props.theme.colours.grey};
+  border-top: none;
   width: 100%;
-  padding: 20px 10px;
-  margin: 10px 0 100px 0;
+  padding: 20px 10px 0 10px;
   display: block;
   @media (min-width: 1220px) {
     display: flex;
@@ -67,25 +66,24 @@ export const Column = styled.div`
 `;
 
 export const Key = styled.div`
+  box-sizing: border-box;
   background-color: white;
   background-color: ${props => props.theme.holidayStatus[props.status]};
-  border: 1px solid ${props => props.theme.holidayStatus[props.status]};
+  border: 2px solid ${props => props.theme.holidayStatus[props.status]};
   color: white;
   font-size: 12px;
   font-weight: 400;
   margin: 4px 4px 4px 0;
   border-radius: 3px;
-  padding: 10px;
+  padding: 8px;
   align-self: auto;
   cursor: pointer;
-  transition: all 300ms;
-  box-shadow: 1px 1px 6px 0px rgba(50, 50, 50, 1);
-
+  transition: all 150ms;
   &:hover {
     opacity: 0.9;
   }
 
   &.selected {
-    box-shadow: inset 1px 1px 6px 0px rgba(50, 50, 50, 0.6);
+    box-shadow: inset 0 0 0 2px white;
   }
 `;

--- a/web-app/src/hoc/Layout/styled.js
+++ b/web-app/src/hoc/Layout/styled.js
@@ -111,7 +111,8 @@ export const LayoutContainer = styled.div`
   min-height: calc(100vh - 40px);
   background-color: white;
   box-sizing: border-box;
-  padding: ${props => (props.history == '/login' ? '0' : '60px 40px')};
+  padding: ${props => (props.history == '/login' ? '0' : '20px')};
+  padding-bottom: none;
   width: calc(100% - 40px);
   transform: ${props =>
     props.history == '/login' ? 'none' : 'translateX(40px)'};

--- a/web-app/src/pages/Dashboard/styled.js
+++ b/web-app/src/pages/Dashboard/styled.js
@@ -12,11 +12,11 @@ export const InnerLayout = styled.div`
     padding: 10px 3px;
     background: ${props => props.theme.colours.unoBlue};
     color: white;
+    border: none !important;
   }
 
   .rbc-off-range-bg {
-    background: ${props => props.theme.colours.grey};
-    border-left: 1px solid transparent !important;
+    background: ${props => props.theme.colours.lightgrey};
     cursor: not-allowed;
   }
 


### PR DESCRIPTION
- Removed border from calendar header cells.
- The calendar header now displays the full day name instead of a shortened version.
- Made the off-range days a little less pronounced and harsh.
- Changed page title to "Booking Dashboard"
- Changed the padding site-wide to be tighter.
- Changed the filter buttons.. the shadow was a bit much. On selection, they get an inset border.

Before-After Comparison:
![chrome_2018-08-07_13-29-02](https://user-images.githubusercontent.com/39301552/43776110-c2faa6c6-9a46-11e8-985b-4c45c87a72ef.png)

![chrome_2018-08-07_13-29-21](https://user-images.githubusercontent.com/39301552/43776112-c43a1efe-9a46-11e8-846b-dcaa3b995ee7.png)
