### PR TITLE
fixed cursor jumping bug in inputs

### DIFF
--- a/web-app/src/components/common/Input/container.js
+++ b/web-app/src/components/common/Input/container.js
@@ -3,7 +3,7 @@ import { PropTypes as PT } from 'prop-types';
 import checkValidity from '../../../utilities/inputValidationRules';
 
 export default Wrapped =>
-  class extends React.Component {
+  class extends React.PureComponent {
     static propTypes = {
       label: PT.string.isRequired,
       type: PT.string.isRequired,


### PR DESCRIPTION
Changed Input class from React.Component to React.PureComponent as it implements shouldComponentUpdate() which was what was required to monitor props.value and prevent the cursor from jumping on change event.