### PR TITLE
Refactor Booking Modal & Ability to create work from home events

### DIFF
--- a/web-app/src/components/BookingModal/BookingModalForm/index.js
+++ b/web-app/src/components/BookingModal/BookingModalForm/index.js
@@ -12,9 +12,8 @@ import Errorbox from '../../common/Errorbox';
 const BookingModalForm = props => {
   const {
     isEventBeingUpdated,
-    submitHolidayRequest,
-    updateHolidayRequest,
-    deleteHolidayRequest,
+    createEvent,
+    updateEvent,
     formData,
     formStatus,
     formIsValid,
@@ -26,12 +25,7 @@ const BookingModalForm = props => {
       return [
         {
           label: 'Update',
-          event: updateHolidayRequest,
-          disabled: !formIsValid || bookingDuration === 0,
-        },
-        {
-          label: 'Cancel',
-          event: deleteHolidayRequest,
+          event: updateEvent,
           disabled: !formIsValid || bookingDuration === 0,
         },
       ];
@@ -39,7 +33,7 @@ const BookingModalForm = props => {
       return [
         {
           label: 'Request',
-          event: submitHolidayRequest,
+          event: createEvent,
           disabled: !formIsValid || bookingDuration === 0,
         },
       ];
@@ -54,7 +48,7 @@ const BookingModalForm = props => {
       const today = new moment();
       const fromTodayToStartDateRequested = getDurationBetweenDates(
         today,
-        start,
+        start
       );
 
       const daysNotice = calculateDaysNotice(bookingDuration);
@@ -134,9 +128,8 @@ BookingModalForm.propTypes = {
   isEventBeingUpdated: PT.bool,
   formStatus: PT.func.isRequired,
   formIsValid: PT.bool.isRequired,
-  submitHolidayRequest: PT.func.isRequired,
-  updateHolidayRequest: PT.func.isRequired,
-  deleteHolidayRequest: PT.func.isRequired,
+  createEvent: PT.func.isRequired,
+  updateEvent: PT.func.isRequired,
 };
 
 BookingModalForm.defaultProps = {

--- a/web-app/src/components/BookingModal/container.js
+++ b/web-app/src/components/BookingModal/container.js
@@ -40,7 +40,11 @@ const Container = Wrapped =>
 
     createEvent = (event, formData) => {
       event.preventDefault();
-      const { employeeId } = this.props;
+      const {
+        employeeId,
+        updateTakenHolidays,
+        toggleBookingModal,
+      } = this.props;
       const { start, end, isHalfday } = formData;
       const eventTypeId = parseInt(formData.eventTypeId);
 
@@ -62,8 +66,8 @@ const Container = Wrapped =>
 
       endpoints[eventTypeId](request)
         .then(() => {
-          this.props.updateTakenHolidays();
-          this.props.toggleBookingModal(false);
+          updateTakenHolidays();
+          toggleBookingModal(false);
         })
         .catch(error => Swal('Error', error.message, 'error'));
     };
@@ -102,7 +106,26 @@ const Container = Wrapped =>
       }
     };
 
-    cancelEvent = (event, formData) => {};
+    cancelEvent = () => {
+      const {
+        updateTakenHolidays,
+        toggleBookingModal,
+        booking: { holidayId },
+      } = this.props;
+      rejectHoliday(holidayId)
+        .then(() => {
+          updateTakenHolidays();
+          toggleBookingModal(false);
+        })
+        .catch(error => {
+          Swal({
+            title: 'Error',
+            text: error.message,
+            type: 'error',
+          });
+          toggleBookingModal(false);
+        });
+    };
 
     render() {
       return (

--- a/web-app/src/components/BookingModal/index.js
+++ b/web-app/src/components/BookingModal/index.js
@@ -19,6 +19,9 @@ const BookingModal = props => {
     updateTakenHolidays,
     isEventBeingUpdated,
     bookingDuration,
+    createEvent,
+    updateEvent,
+    cancelEvent,
   } = props;
 
   return (
@@ -43,6 +46,8 @@ const BookingModal = props => {
               updateTakenHolidays={updateTakenHolidays}
               employeeId={employeeId}
               booking={booking}
+              createEvent={createEvent}
+              updateEvent={updateEvent}
             />
           </FormContainer>
         </StyleContainer>
@@ -58,6 +63,9 @@ BookingModal.propTypes = {
   bookingModalOpen: PT.bool,
   updateTakenHolidays: PT.func.isRequired,
   bookingDuration: PT.number,
+  createEvent: PT.func.isRequired,
+  updateEvent: PT.func.isRequired,
+  cancelEvent: PT.func.isRequired,
 };
 
 export default container(BookingModal);

--- a/web-app/src/components/BookingModal/index.js
+++ b/web-app/src/components/BookingModal/index.js
@@ -3,12 +3,9 @@ import container from './container';
 import { PropTypes as PT } from 'prop-types';
 import BookingModalForm from './BookingModalForm';
 import { Modal } from '../common';
-import {
-  StyleContainer,
-  BookingStatus,
-  StatusDot,
-  FormContainer,
-} from './styled';
+import { StyleContainer, BookingStatus, FormContainer } from './styled';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faTrash } from '@fortawesome/fontawesome-free-solid';
 
 const BookingModal = props => {
   const {
@@ -28,20 +25,25 @@ const BookingModal = props => {
     bookingModalOpen && (
       <Modal closeModal={closeBookingModal}>
         <StyleContainer>
-          <p onClick={cancelEvent}>Cancel</p>
+          {isEventBeingUpdated && (
+            <BookingStatus status={booking.eventStatus.eventStatusId}>
+              <div>
+                <h4>{booking.title}</h4>
+                <p>{booking.eventStatus.description}</p>
+              </div>
+              <div>
+                <div className="cancelEvent" onClick={cancelEvent}>
+                  <FontAwesomeIcon icon={faTrash} />
+                  Cancel Event
+                </div>
+              </div>
+            </BookingStatus>
+          )}
           <h1>
             {isEventBeingUpdated ? 'Update Booking' : 'Request a Booking'}
           </h1>
           <h4 id="totalDaysToBook">Total days: {bookingDuration}</h4>
-          {isEventBeingUpdated && (
-            <BookingStatus>
-              <h4>{booking.title}</h4>
-              <span>
-                <StatusDot status={booking.eventStatus.eventStatusId} />
-                {booking.eventStatus.description}
-              </span>
-            </BookingStatus>
-          )}
+
           <FormContainer>
             <BookingModalForm
               updateTakenHolidays={updateTakenHolidays}

--- a/web-app/src/components/BookingModal/index.js
+++ b/web-app/src/components/BookingModal/index.js
@@ -28,6 +28,7 @@ const BookingModal = props => {
     bookingModalOpen && (
       <Modal closeModal={closeBookingModal}>
         <StyleContainer>
+          <p onClick={cancelEvent}>Cancel</p>
           <h1>
             {isEventBeingUpdated ? 'Update Booking' : 'Request a Booking'}
           </h1>

--- a/web-app/src/components/BookingModal/styled.js
+++ b/web-app/src/components/BookingModal/styled.js
@@ -14,45 +14,40 @@ export const StyleContainer = styled.div`
   h1 {
     margin: 0 0 10px 0;
   }
+
+  h4 {
+    margin: 0;
+  }
 `;
 
 export const BookingStatus = styled.div`
-  background: ${props => props.theme.colours.lightgrey};
-  padding: 10px 35px;
-  margin: 10px -35px;
-  @media (min-width: 920px) {
-    padding: 10px 54px;
-    margin: 10px -54px;
-  }
-
-  h4,
-  span {
-    position: relative;
-    margin: 0 0 4px 0;
-  }
-
-  span {
-    left: -13px;
-  }
-`;
-
-export const StatusDot = styled.div`
-  display: inline-block;
-  position: relative;
-  top: -2.5px;
-  margin-right: 7px;
-  height: 7px;
-  width: 7px;
-  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: white;
   background: ${({ theme, status }) => theme.holidayStatus[status]};
+  padding: 10px;
+  margin-bottom: 20px;
+  border-radius: 3px;
+  p {
+    margin: 4px 0 0 0;
+  }
+  svg {
+    margin-right: 5px;
+  }
+
+  .cancelEvent {
+    cursor: pointer;
+    border: 1.5px solid white;
+    padding: 10px; 15px;
+    border-radius: 3px;
+  }
 `;
 
 export const FormContainer = styled.div`
   position: relative;
-  padding-top: 15px;
 
   form {
-    margin: 15px 0;
     @media (min-width: 992px) {
       margin-right: -10px;
       margin-left: -10px;
@@ -80,7 +75,7 @@ export const FormContainer = styled.div`
 
     .checkbox {
       @media (min-width: 992px) {
-        margin: 20px 10px;
+        margin: 0 10px 20px 10px;
       }
     }
 

--- a/web-app/src/services/holidayService.js
+++ b/web-app/src/services/holidayService.js
@@ -1,9 +1,5 @@
 import axios from '../utilities/AxiosInstance';
 
-export const cancelHoliday = holidayId => {
-  return axios.post(`/holidays/cancel/${holidayId}`);
-};
-
 export const getAllHolidays = () => {
   return axios.get('/holidays/');
 };

--- a/web-app/src/services/wfhService.js
+++ b/web-app/src/services/wfhService.js
@@ -1,11 +1,11 @@
 import axios from '../utilities/AxiosInstance';
 
-export const createWFH = holidayId => {
-  return axios.post(`/workingFromHome/${holidayId}`);
+export const requestWFH = dates => {
+  return axios.post('/workingFromHome/', dates);
 };
 
-export const getAllWFH = dates => {
-  return axios.get('/workingFromHome/', dates);
+export const getAllWFH = () => {
+  return axios.get('/workingFromHome/');
 };
 
 export const getWFH = employeeId => {

--- a/web-app/src/services/wfhService.js
+++ b/web-app/src/services/wfhService.js
@@ -1,0 +1,17 @@
+import axios from '../utilities/AxiosInstance';
+
+export const createWFH = holidayId => {
+  return axios.post(`/workingFromHome/${holidayId}`);
+};
+
+export const getAllWFH = dates => {
+  return axios.get('/workingFromHome/', dates);
+};
+
+export const getWFH = employeeId => {
+  return axios.get(`/workingFromHome/findByEmployeeId/${employeeId}`);
+};
+
+export const getWFHById = wfhId => {
+  return axios.get(`/workingFromHome/${wfhId}`);
+};

--- a/web-app/src/utilities/eventTypes.js
+++ b/web-app/src/utilities/eventTypes.js
@@ -1,0 +1,6 @@
+export default {
+  HOLIDAY: 1,
+  WFH: 2,
+  SICK: 3,
+  TRAVEL: 4,
+};


### PR DESCRIPTION
- Refactored `BookingModal` and `BookingModalForm`.
  - The main difference is all requests are now moved into the `BookingModal` container, for two reasons:
     1. Such important calls felt very hidden in the file structure.
     2. Cancel holiday call has nothing to do with the form, so it made sense to have all these requests together in the `BookingModal` container
  - General code clean up, removing duplicated code that wasn't required.
- You can now create a work from home event. Note it doesn't display on the calendar yet.
- Moved and restyled cancel event button so it's not mistaken as a close modal button.

![chrome_2018-08-16_15-31-52](https://user-images.githubusercontent.com/39301552/44215083-86ccb200-a169-11e8-9c48-aa668564706a.png)
