### PR TITLE
[TS-27] Add conditional checks to show approval buttons to holiday modal

### DIFF
--- a/web-app/src/components/AllHolidays/index.jsx
+++ b/web-app/src/components/AllHolidays/index.jsx
@@ -12,7 +12,11 @@ export const AllHolidays = ({
 }) => {
   return (
     <Fragment>
-      <HolidayModal holiday={selectedHoliday} closeModal={() => closeModal()} />
+      <HolidayModal
+        holiday={selectedHoliday}
+        closeModal={() => closeModal()}
+        showAdminControls
+      />
       <h2>All Holidays</h2>
       <DataTable
         data={holidays}

--- a/web-app/src/components/HolidayModal/container.js
+++ b/web-app/src/components/HolidayModal/container.js
@@ -1,16 +1,25 @@
 import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 import { isEmpty } from 'lodash';
 import { approveHoliday, rejectHoliday } from '../../services/holidayService';
 import swal from 'sweetalert2';
 import holidayStatus from '../../utilities/holidayStatus';
 import { Toast } from '../../utilities/Notifications';
+import { getUser } from '../../reducers';
 
-export default Wrapped =>
+const HolidayModalContainer = Wrapped =>
   class extends Component {
     static propTypes = {
       holiday: PT.object.isRequired,
       closeModal: PT.func.isRequired,
+      showAdminControls: PT.bool,
+      userDetails: PT.object.isRequired,
+    };
+
+    static defaultProps = {
+      showAdminControls: true,
     };
 
     constructor(props) {
@@ -77,7 +86,7 @@ export default Wrapped =>
     };
 
     render() {
-      const { closeModal } = this.props;
+      const { closeModal, userDetails, showAdminControls } = this.props;
       const { holiday } = this.state;
       if (isEmpty(holiday)) return null;
       return (
@@ -86,7 +95,17 @@ export default Wrapped =>
           closeModal={closeModal}
           approveHoliday={this.approveHoliday}
           rejectHoliday={this.rejectHoliday}
+          userDetails={userDetails}
+          showAdminControls={showAdminControls}
         />
       );
     }
   };
+
+const mapStateToProps = state => {
+  return {
+    userDetails: getUser(state),
+  };
+};
+
+export default compose(connect(mapStateToProps), HolidayModalContainer);

--- a/web-app/src/components/HolidayModal/container.js
+++ b/web-app/src/components/HolidayModal/container.js
@@ -19,7 +19,7 @@ const HolidayModalContainer = Wrapped =>
     };
 
     static defaultProps = {
-      showAdminControls: true,
+      showAdminControls: false,
     };
 
     constructor(props) {

--- a/web-app/src/components/HolidayModal/index.js
+++ b/web-app/src/components/HolidayModal/index.js
@@ -5,15 +5,26 @@ import { Modal, Button, Email } from '../../components/common';
 import { StyleContainer, Stat, StatWrap, ButtonWrap, StatusH2 } from './styled';
 import { getEventDayAmount } from '../../utilities/dates';
 import { statusText } from '../../utilities/holidayStatus';
+import roles from '../../utilities/roles';
 
 const HolidayModal = ({
   closeModal,
   holiday,
   approveHoliday,
   rejectHoliday,
+  userDetails,
+  showAdminControls,
 }) => {
   const { start, end, employee, eventStatus } = holiday;
-  const { forename, surname, email } = employee;
+  const { forename, surname, email, employeeId } = employee;
+  const isAdmin = userDetails.employeeRoleId === roles.ADMIN;
+
+  const shouldShowAdminControls = () => {
+    if (!isAdmin) return false;
+    if (userDetails.employeeId === employeeId) return false;
+    if (!showAdminControls) return false;
+    return true;
+  };
 
   const duration = getEventDayAmount(holiday);
   return (
@@ -49,10 +60,12 @@ const HolidayModal = ({
             <h4>Duration</h4>
           </Stat>
         </StatWrap>
-        <ButtonWrap>
-          <Button label="Approve" onClick={approveHoliday} />
-          <Button label="Reject" onClick={rejectHoliday} />
-        </ButtonWrap>
+        {shouldShowAdminControls() && (
+          <ButtonWrap>
+            <Button label="Approve" onClick={approveHoliday} />
+            <Button label="Reject" onClick={rejectHoliday} />
+          </ButtonWrap>
+        )}
       </StyleContainer>
     </Modal>
   );
@@ -63,6 +76,8 @@ HolidayModal.propTypes = {
   holiday: PT.object.isRequired,
   approveHoliday: PT.func.isRequired,
   rejectHoliday: PT.func.isRequired,
+  userDetails: PT.object.isRequired,
+  showAdminControls: PT.bool.isRequired,
 };
 
 export default container(HolidayModal);

--- a/web-app/src/components/PendingHolidays/index.jsx
+++ b/web-app/src/components/PendingHolidays/index.jsx
@@ -12,7 +12,11 @@ export const PendingHolidays = ({
 }) => {
   return (
     <Fragment>
-      <HolidayModal holiday={selectedHoliday} closeModal={() => closeModal()} />
+      <HolidayModal
+        holiday={selectedHoliday}
+        closeModal={() => closeModal()}
+        showAdminControls
+      />
       <h2>Manage Pending Holidays</h2>
       <DataTable
         data={pendingHolidays}

--- a/web-app/src/pages/Profile/index.jsx
+++ b/web-app/src/pages/Profile/index.jsx
@@ -19,11 +19,7 @@ const Profile = props => {
 
   return (
     <Fragment>
-      <HolidayModal
-        holiday={selectedHoliday}
-        closeModal={closeModal}
-        showAdminControls={false}
-      />
+      <HolidayModal holiday={selectedHoliday} closeModal={closeModal} />
       <MainContentContainer>
         <div>
           <h2>

--- a/web-app/src/pages/Profile/index.jsx
+++ b/web-app/src/pages/Profile/index.jsx
@@ -19,7 +19,11 @@ const Profile = props => {
 
   return (
     <Fragment>
-      <HolidayModal holiday={selectedHoliday} closeModal={closeModal} />
+      <HolidayModal
+        holiday={selectedHoliday}
+        closeModal={closeModal}
+        showAdminControls={false}
+      />
       <MainContentContainer>
         <div>
           <h2>

--- a/web-app/src/pages/TeamDashboard/index.js
+++ b/web-app/src/pages/TeamDashboard/index.js
@@ -29,7 +29,11 @@ export const User = ({
           history={history}
         />
       )}
-      <HolidayModal holiday={selectedHoliday} closeModal={hideHolidayModal} />
+      <HolidayModal
+        holiday={selectedHoliday}
+        closeModal={hideHolidayModal}
+        showAdminControls
+      />
       <h2>My Team</h2>
       <Columns>
         <Stat>

--- a/web-app/src/pages/User/index.jsx
+++ b/web-app/src/pages/User/index.jsx
@@ -20,7 +20,11 @@ export const User = props => {
 
   return (
     <Container>
-      <HolidayModal holiday={selectedHoliday} closeModal={closeModal} />
+      <HolidayModal
+        holiday={selectedHoliday}
+        closeModal={closeModal}
+        showAdminControls
+      />
       <div>
         <p className="return" onClick={props.history.goBack}>
           <FontAwesomeIcon icon={faArrowLeft} />Return


### PR DESCRIPTION
- Added `showAdminControls` prop to `HolidayModal`. Defaults to true as it's the most used use-case.
- Admin controls will now not show in holiday modal if the user is not an admin.
- Admin controls will now not show in holiday modal if an admin is viewing their own holidays.