### PR TITLE
Implement new dashboard call

### DIFF
--- a/web-app/src/actions/dashboard.js
+++ b/web-app/src/actions/dashboard.js
@@ -1,5 +1,4 @@
 import * as actionTypes from '../actionTypes';
-import { getHolidays } from '../services/holidayService';
 import { getUsersEvents } from '../services/dashboardService';
 
 import {

--- a/web-app/src/actions/dashboard.js
+++ b/web-app/src/actions/dashboard.js
@@ -1,5 +1,7 @@
 import * as actionTypes from '../actionTypes';
-import { getAllHolidays, getHolidays } from '../services/holidayService';
+import { getHolidays } from '../services/holidayService';
+import { getUsersEvents } from '../services/dashboardService';
+
 import {
   formatEventsForCalendar,
   getEventDuration,
@@ -53,19 +55,8 @@ export const setError = error => {
 
 // Thunks
 
-export const fetchEvents = () => dispatch => {
-  getAllHolidays()
-    .then(({ data }) => {
-      const formattedEvents = formatEventsForCalendar(data);
-      dispatch(setCalendarEvents(formattedEvents));
-    })
-    .catch(error => {
-      dispatch(setError(error));
-    });
-};
-
-export const fetchEventsByUserId = userId => dispatch => {
-  getHolidays(userId)
+export const fetchEvents = date => dispatch => {
+  getUsersEvents(date)
     .then(({ data }) => {
       const formattedEvents = formatEventsForCalendar(data);
       dispatch(setCalendarEvents(formattedEvents));

--- a/web-app/src/pages/Dashboard/container.js
+++ b/web-app/src/pages/Dashboard/container.js
@@ -2,15 +2,15 @@ import React from 'react';
 import { PropTypes as PT } from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { fetchEvents, fetchEventsByUserId } from '../../actions/dashboard';
+import { fetchEvents } from '../../actions/dashboard';
 import { getUser, getTakenHolidays, eventBeingUpdated } from '../../reducers';
+import moment from 'moment';
 
 const DashboardContainer = Wrapped =>
   class extends React.Component {
     static propTypes = {
       userDetails: PT.object,
       fetchEvents: PT.func.isRequired,
-      fetchEventsByUserId: PT.func.isRequired,
       takenEvents: PT.array,
       isEventBeingUpdated: PT.bool,
     };
@@ -18,6 +18,7 @@ const DashboardContainer = Wrapped =>
     constructor(props) {
       super(props);
       this.state = {
+        calendarDate: new moment(),
         filteredEvents: [],
         activeEventIds: [],
         activeEmployee: -1,
@@ -25,7 +26,8 @@ const DashboardContainer = Wrapped =>
     }
 
     componentDidMount() {
-      this.props.fetchEvents();
+      const { calendarDate } = this.state;
+      this.props.fetchEvents(calendarDate.format('YYYY-MM-DD'));
     }
 
     componentDidUpdate = prevProps => {
@@ -78,6 +80,11 @@ const DashboardContainer = Wrapped =>
       this.setState({ activeEmployee: employeeId }, this.filterCalenderEvents);
     };
 
+    fetchEvents = () => {
+      const { calendarDate } = this.state;
+      this.props.fetchEvents(calendarDate.format('YYYY-MM-DD'));
+    };
+
     render() {
       return (
         this.props.userDetails && (
@@ -85,7 +92,7 @@ const DashboardContainer = Wrapped =>
             employeeId={this.props.userDetails.employeeId}
             takenEvents={this.props.takenEvents}
             events={this.state.filteredEvents}
-            updateTakenEvents={this.props.fetchEvents}
+            updateTakenEvents={this.fetchEvents}
             isEventBeingUpdated={this.props.isEventBeingUpdated}
             onUpdateEvents={activeEventIds =>
               this.setActiveEvents(activeEventIds)
@@ -110,9 +117,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    fetchEvents: () => dispatch(fetchEvents()),
-    fetchEventsByUserId: employeeId =>
-      dispatch(fetchEventsByUserId(employeeId)),
+    fetchEvents: date => dispatch(fetchEvents(date)),
   };
 };
 

--- a/web-app/src/pages/Dashboard/container.js
+++ b/web-app/src/pages/Dashboard/container.js
@@ -26,8 +26,7 @@ const DashboardContainer = Wrapped =>
     }
 
     componentDidMount() {
-      const { calendarDate } = this.state;
-      this.props.fetchEvents(calendarDate.format('YYYY-MM-DD'));
+      this.fetchEvents();
     }
 
     componentDidUpdate = prevProps => {

--- a/web-app/src/services/dashboardService.js
+++ b/web-app/src/services/dashboardService.js
@@ -1,0 +1,5 @@
+import axios from '../utilities/AxiosInstance';
+
+export const getUsersEvents = date => {
+  return axios.get(`/dashboard/getEmployeeEvents?date=${date}`);
+};

--- a/web-app/src/utilities/AxiosInstance.js
+++ b/web-app/src/utilities/AxiosInstance.js
@@ -43,12 +43,12 @@ instance.interceptors.response.use(function(response) {
   if (response.config.url.includes(`${baseURL}/dashboard/getEmployeeEvents`)) {
     const events = [...response.data.events];
     const employee = store.getState().USER;
-    for (const index in events) {
+    for (let event of events) {
       // Raw dates to moment objects
-      events[index].start = new moment(events[index].startDate, 'YYYY-MM-DD');
-      events[index].end = new moment(events[index].endDate, 'YYYY-MM-DD');
+      event.start = new moment(event.startDate, 'YYYY-MM-DD');
+      event.end = new moment(event.endDate, 'YYYY-MM-DD');
       // Append logged in employee
-      events[index].employee = { ...employee };
+      event.employee = { ...employee };
     }
     return {
       ...response,

--- a/web-app/src/utilities/AxiosInstance.js
+++ b/web-app/src/utilities/AxiosInstance.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import moment from 'moment';
+import store from '../store';
 
 const baseURL = process.env.DOMAIN;
 
@@ -34,6 +35,24 @@ instance.interceptors.response.use(function(response) {
     return {
       ...response,
       data: holidays,
+    };
+  }
+
+  // Append employee to each event (we know its the logged in user) and convert
+  // dates to moment objects
+  if (response.config.url.includes(`${baseURL}/dashboard/getEmployeeEvents`)) {
+    const events = [...response.data.events];
+    const employee = store.getState().USER;
+    for (const index in events) {
+      // Raw dates to moment objects
+      events[index].start = new moment(events[index].startDate, 'YYYY-MM-DD');
+      events[index].end = new moment(events[index].endDate, 'YYYY-MM-DD');
+      // Append logged in employee
+      events[index].employee = { ...employee };
+    }
+    return {
+      ...response,
+      data: events,
     };
   }
 


### PR DESCRIPTION
- Dashboard now only shows events for the logged in user for the displayed month.
- When the new call is responding it is intercepted. At this point, the dates are changed to moment objects and we tack on information about the currently logged in user to each event for seamless integration with the current calendar logic.
- Cleaned up some stuff that isn't used any more.

I haven't yet made the request fire again when the month is changed to keep this PR nice and small.