### PR TITLE
Changing month now requests data for that month

### DIFF
--- a/web-app/src/components/BookingCalendar/container.js
+++ b/web-app/src/components/BookingCalendar/container.js
@@ -127,19 +127,15 @@ const BookingCalendarContainer = Wrapped =>
       }
     };
 
-    onNavigate = date => {
-      const newDate = new moment(date);
-      this.props.onNavigate(newDate);
-    };
-
     render() {
+      const { employeeId, events, onNavigate } = this.props;
       return (
-        this.props.employeeId &&
-        this.props.events && (
+        employeeId &&
+        events && (
           <Wrapped
             onSelectSlot={this.onSelectSlot}
             onSelectEvent={this.onSelectEvent}
-            onNavigate={this.onNavigate}
+            onNavigate={onNavigate}
             events={this.props.events}
           />
         )

--- a/web-app/src/components/BookingCalendar/container.js
+++ b/web-app/src/components/BookingCalendar/container.js
@@ -24,6 +24,7 @@ const BookingCalendarContainer = Wrapped =>
       updateEventDuration: PT.func,
       setEventBeingUpdated: PT.func,
       toggleBookingModal: PT.func,
+      onNavigate: PT.func,
     };
 
     constructor(props) {
@@ -52,11 +53,11 @@ const BookingCalendarContainer = Wrapped =>
         if (employee && employee.employeeId === employeeId) {
           var selectedDateRange = moment.range(
             moment(start),
-            moment(end).endOf('day'),
+            moment(end).endOf('day')
           );
           var existingEvent = moment.range(
             moment(event.start),
-            moment(event.end),
+            moment(event.end)
           );
           if (selectedDateRange.overlaps(existingEvent)) {
             return true;
@@ -73,7 +74,7 @@ const BookingCalendarContainer = Wrapped =>
       } else {
         const datesOverlapExisting = this.selectedDatesOverlapExisting(
           start,
-          end,
+          end
         );
         if (datesOverlapExisting) {
           return 'Your are trying to request dates that have already been set';
@@ -126,6 +127,11 @@ const BookingCalendarContainer = Wrapped =>
       }
     };
 
+    onNavigate = date => {
+      const newDate = new moment(date);
+      this.props.onNavigate(newDate);
+    };
+
     render() {
       return (
         this.props.employeeId &&
@@ -133,6 +139,7 @@ const BookingCalendarContainer = Wrapped =>
           <Wrapped
             onSelectSlot={this.onSelectSlot}
             onSelectEvent={this.onSelectEvent}
+            onNavigate={this.onNavigate}
             events={this.props.events}
           />
         )
@@ -151,9 +158,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 export default compose(
-  connect(
-    null,
-    mapDispatchToProps,
-  ),
-  BookingCalendarContainer,
+  connect(null, mapDispatchToProps),
+  BookingCalendarContainer
 );

--- a/web-app/src/components/BookingCalendar/index.jsx
+++ b/web-app/src/components/BookingCalendar/index.jsx
@@ -10,7 +10,13 @@ moment.locale('en-gb');
 Calendar.momentLocalizer(moment);
 
 export const BookingCalendar = props => {
-  const { onSelectSlot, onSelectEvent, events } = props;
+  const { onSelectSlot, onSelectEvent, events, onNavigate } = props;
+
+  const updateOnNavigate = date => {
+    const newDate = new moment(date);
+    onNavigate(newDate);
+  };
+
   return (
     <Calendar
       components={{ eventWrapper: Event, toolbar: BigCalendarToolbar }}
@@ -27,6 +33,7 @@ export const BookingCalendar = props => {
       formats={{
         weekdayFormat: 'dddd',
       }}
+      onNavigate={updateOnNavigate}
     />
   );
 };
@@ -34,6 +41,7 @@ export const BookingCalendar = props => {
 BookingCalendar.propTypes = {
   onSelectSlot: PT.func.isRequired,
   onSelectEvent: PT.func.isRequired,
+  onNavigate: PT.func.isRequired,
   events: PT.array.isRequired,
 };
 

--- a/web-app/src/components/BookingCalendar/index.jsx
+++ b/web-app/src/components/BookingCalendar/index.jsx
@@ -12,11 +12,6 @@ Calendar.momentLocalizer(moment);
 export const BookingCalendar = props => {
   const { onSelectSlot, onSelectEvent, events, onNavigate } = props;
 
-  const updateOnNavigate = date => {
-    const newDate = new moment(date);
-    onNavigate(newDate);
-  };
-
   return (
     <Calendar
       components={{ eventWrapper: Event, toolbar: BigCalendarToolbar }}
@@ -33,7 +28,7 @@ export const BookingCalendar = props => {
       formats={{
         weekdayFormat: 'dddd',
       }}
-      onNavigate={updateOnNavigate}
+      onNavigate={onNavigate}
     />
   );
 };

--- a/web-app/src/pages/Dashboard/container.js
+++ b/web-app/src/pages/Dashboard/container.js
@@ -18,7 +18,7 @@ const DashboardContainer = Wrapped =>
     constructor(props) {
       super(props);
       this.state = {
-        calendarDate: new moment(),
+        calendarDate: new moment().startOf('month').format('YYYY-MM-DD'),
         filteredEvents: [],
         activeEventIds: [],
         activeEmployee: -1,
@@ -79,9 +79,18 @@ const DashboardContainer = Wrapped =>
       this.setState({ activeEmployee: employeeId }, this.filterCalenderEvents);
     };
 
+    handleCalendarNavigate = date => {
+      this.setState(
+        {
+          calendarDate: date.startOf('month').format('YYYY-MM-DD'),
+        },
+        this.fetchEvents
+      );
+    };
+
     fetchEvents = () => {
       const { calendarDate } = this.state;
-      this.props.fetchEvents(calendarDate.format('YYYY-MM-DD'));
+      this.props.fetchEvents(calendarDate);
     };
 
     render() {
@@ -99,6 +108,7 @@ const DashboardContainer = Wrapped =>
             onUpdateEmployee={employeeId =>
               this.setActiveEmployee(parseInt(employeeId))
             }
+            onCalendarNavigate={this.handleCalendarNavigate}
           />
         )
       );

--- a/web-app/src/pages/Dashboard/container.js
+++ b/web-app/src/pages/Dashboard/container.js
@@ -80,9 +80,10 @@ const DashboardContainer = Wrapped =>
     };
 
     handleCalendarNavigate = date => {
+      const newDate = new moment(date);
       this.setState(
         {
-          calendarDate: date.startOf('month').format('YYYY-MM-DD'),
+          calendarDate: newDate.startOf('month').format('YYYY-MM-DD'),
         },
         this.fetchEvents
       );

--- a/web-app/src/pages/Dashboard/index.jsx
+++ b/web-app/src/pages/Dashboard/index.jsx
@@ -13,7 +13,9 @@ export const Dashboard = props => {
     onUpdateEvents,
     onUpdateEmployee,
     isEventBeingUpdated,
+    onCalendarNavigate,
   } = props;
+
   return (
     <Fragment>
       <BookingModal
@@ -26,6 +28,7 @@ export const Dashboard = props => {
           employeeId={employeeId}
           events={events}
           isEventBeingUpdated={isEventBeingUpdated}
+          onNavigate={onCalendarNavigate}
         />
         <Legend
           updateCalendarEvents={onUpdateEvents}
@@ -45,6 +48,7 @@ Dashboard.propTypes = {
   updateTakenEvents: PT.func.isRequired,
   employeeId: PT.number,
   isEventBeingUpdated: PT.bool,
+  onCalendarNavigate: PT.func.isRequired,
 };
 
 Dashboard.defaultProps = {


### PR DESCRIPTION
When the calendar is moved back or forth in months a new request is fired to populate the events for that month.

Again, keeping these PR's small so still to do as far as I'm concerned:
- Append new months to existing months instead of overwrite (this could be tough to do)
- Create a full-page loading state with redux to trigger while these requests are being made.