### PR TITLE
Add loading to dashboard fetch events call

### DIFF
--- a/web-app/src/actions/dashboard.js
+++ b/web-app/src/actions/dashboard.js
@@ -1,5 +1,6 @@
 import * as actionTypes from '../actionTypes';
 import { getUsersEvents } from '../services/dashboardService';
+import { setLoading } from './loading';
 
 import {
   formatEventsForCalendar,
@@ -55,12 +56,15 @@ export const setError = error => {
 // Thunks
 
 export const fetchEvents = date => dispatch => {
+  dispatch(setLoading(true));
   getUsersEvents(date)
     .then(({ data }) => {
+      dispatch(setLoading(false));
       const formattedEvents = formatEventsForCalendar(data);
       dispatch(setCalendarEvents(formattedEvents));
     })
     .catch(error => {
+      dispatch(setLoading(false));
       dispatch(setError(error));
     });
 };


### PR DESCRIPTION
The page will now load when fetching events.
Depends on global page loading branch.