### PR TITLE
quick fix on selecting 4 days not displaying duration warning

### DIFF
--- a/web-app/src/utilities/dates.js
+++ b/web-app/src/utilities/dates.js
@@ -50,7 +50,7 @@ export const getDurationBetweenDates = (startDate, endDate) => {
 };
 
 export const calculateDaysNotice = daysRequested => {
-  if (daysRequested < 4) {
+  if (daysRequested <= 4) {
     return 10;
   } else if (daysRequested > 4 && daysRequested < 10) {
     return 20;


### PR DESCRIPTION
Quick fix where selecting 4 days right after current day, not displaying warning