### PR TITLE
Fix/responsive layout for team dashboard & calendar toolbar

### DIFF
--- a/web-app/src/components/BigCalendarToolbar/styled.js
+++ b/web-app/src/components/BigCalendarToolbar/styled.js
@@ -2,8 +2,12 @@ import styled from 'styled-components';
 
 export const StyleContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   margin: 0 0 15px 0;
+  @media (min-width: ${props => props.theme.mediaQueries.md}) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
 
   h2 {
     margin: 0 0 0px 0;

--- a/web-app/src/pages/TeamDashboard/styled.js
+++ b/web-app/src/pages/TeamDashboard/styled.js
@@ -13,13 +13,22 @@ export const Stat = styled.div`
 export const Columns = styled.div`
   display: flex;
   margin-bottom: 20px;
-  > div {
-    width: 50%;
-    :first-of-type {
-      margin-right: 10px;
-    }
-    :last-of-type {
-      margin-left: 10px;
+  flex-direction: column;
+  @media (min-width: ${props => props.theme.mediaQueries.lg}) {
+    justify-content: space-around;
+    flex-direction: row;
+  }
+
+  &:last-of-type > div {
+    margin: 15px 0;
+    @media (min-width: ${props => props.theme.mediaQueries.lg}) {
+      width: 50%;
+      :first-of-type {
+        margin: 0 10px 0 0;
+      }
+      :last-of-type {
+        margin: 0 0 0 10px;
+      }
     }
   }
 `;


### PR DESCRIPTION
- Stacking calendar buttons underneath calendar title when user smaller devices.
- Stacking columns on teams dashboard when on smaller devices