### PR TITLE
Calendar slot selection validation and booking form onchange validation

### DIFF
--- a/web-app/src/components/BookingCalendar/container.js
+++ b/web-app/src/components/BookingCalendar/container.js
@@ -3,6 +3,7 @@ import { PropTypes as PT } from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import {
+  validationMessage,
   checkIfPastDatesSelected,
   checkIfDatesFallOnWeekend,
   checkIfSelectedDatesOverlapExisting,
@@ -51,9 +52,9 @@ const BookingCalendarContainer = Wrapped =>
       const pastDatesSelected = checkIfPastDatesSelected(start);
       const datesFallOnWeekend = checkIfDatesFallOnWeekend(start, end);
       if (pastDatesSelected) {
-        return 'Unable to select past dates';
+        return validationMessage.PAST_DATES_SELECTED;
       } else if (datesFallOnWeekend) {
-        return 'Unable to select weekend dates';
+        return validationMessage.WEEKEND_DATES_SELECTED;
       } else {
         const datesOverlapExisting = checkIfSelectedDatesOverlapExisting(
           events,
@@ -62,9 +63,9 @@ const BookingCalendarContainer = Wrapped =>
           end,
         );
         if (datesOverlapExisting) {
-          return 'You cannot request dates that have already been set';
+          return validationMessage.DATES_ALREADY_REQUESTED;
         } else {
-          return 'Dates approved';
+          return validationMessage.DATES_APPROVED;
         }
       }
     };
@@ -74,7 +75,7 @@ const BookingCalendarContainer = Wrapped =>
         start,
         end,
       );
-      if (calendarValidationResults === 'Dates approved') {
+      if (calendarValidationResults === validationMessage.DATES_APPROVED) {
         let booking = {
           start: new moment(start),
           end: new moment(end),

--- a/web-app/src/components/BookingCalendar/container.js
+++ b/web-app/src/components/BookingCalendar/container.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes as PT } from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { validateSelectedDates } from '../../utilities/dashboardEvents';
 import {
   selectBooking,
   toggleBookingModal,
@@ -41,51 +42,14 @@ const BookingCalendarContainer = Wrapped =>
       this.props.setEventBeingUpdated(isBeingUpdated);
     };
 
-    checkIfPastDatesSelected = start => {
-      const today = new moment();
-      return moment(start).isBefore(today);
-    };
-
-    selectedDatesOverlapExisting = (start, end) => {
-      const { events, employeeId } = this.props;
-      const overlappingEvents = events.filter(event => {
-        const { employee } = event;
-        if (employee && employee.employeeId === employeeId) {
-          var selectedDateRange = moment.range(
-            moment(start),
-            moment(end).endOf('day')
-          );
-          var existingEvent = moment.range(
-            moment(event.start),
-            moment(event.end)
-          );
-          if (selectedDateRange.overlaps(existingEvent)) {
-            return true;
-          }
-        }
-      });
-      return overlappingEvents.length > 0;
-    };
-
-    validateSelectedDates = (start, end) => {
-      const pastDatesSelected = this.checkIfPastDatesSelected(start);
-      if (pastDatesSelected) {
-        return 'Unable to select past dates';
-      } else {
-        const datesOverlapExisting = this.selectedDatesOverlapExisting(
-          start,
-          end
-        );
-        if (datesOverlapExisting) {
-          return 'You\'re are trying to request dates that have already been set';
-        } else {
-          return 'Dates approved';
-        }
-      }
-    };
-
     onSelectSlot = ({ start, end }) => {
-      const validatingDatesResult = this.validateSelectedDates(start, end);
+      const { events, employeeId } = this.props;
+      const validatingDatesResult = validateSelectedDates(
+        events,
+        employeeId,
+        start,
+        end,
+      );
       if (validatingDatesResult === 'Dates approved') {
         let booking = {
           start: new moment(start),
@@ -152,6 +116,9 @@ const mapDispatchToProps = dispatch => {
 };
 
 export default compose(
-  connect(null, mapDispatchToProps),
-  BookingCalendarContainer
+  connect(
+    null,
+    mapDispatchToProps,
+  ),
+  BookingCalendarContainer,
 );

--- a/web-app/src/components/BookingModal/BookingModalForm/container.js
+++ b/web-app/src/components/BookingModal/BookingModalForm/container.js
@@ -6,13 +6,14 @@ import { selectBooking, updateEventDuration } from '../../../actions/dashboard';
 import {
   checkIfPastDatesSelected,
   checkIfDatesFallOnWeekend,
+  checkIfSelectedDatesOverlapExisting,
   startDateValidation,
   endDateValidation,
   halfDayValidation,
 } from '../../../utilities/dashboardEvents';
 import { Toast } from '../../../utilities/Notifications';
 import moment from 'moment';
-import { eventBeingUpdated } from '../../../reducers';
+import { getUser, getAllEvents, eventBeingUpdated } from '../../../reducers';
 
 const Container = Wrapped =>
   class extends React.Component {
@@ -68,7 +69,24 @@ const Container = Wrapped =>
       } else if (datesFallOnWeekend) {
         return 'Unable to select weekend dates';
       } else {
-        return 'Dates approved';
+        const {
+          userDetails: { employeeId },
+          allEvents,
+          booking: { eventId },
+        } = this.props;
+
+        const datesOverlapExisting = checkIfSelectedDatesOverlapExisting(
+          allEvents,
+          employeeId,
+          start,
+          end,
+          eventId,
+        );
+        if (datesOverlapExisting) {
+          return 'You cannot request dates that have already been set';
+        } else {
+          return 'Dates approved';
+        }
       }
     }
 
@@ -137,6 +155,8 @@ const Container = Wrapped =>
 
 const mapStateToProps = state => {
   return {
+    userDetails: getUser(state),
+    allEvents: getAllEvents(state),
     isEventBeingUpdated: eventBeingUpdated(state),
   };
 };

--- a/web-app/src/components/BookingModal/BookingModalForm/container.js
+++ b/web-app/src/components/BookingModal/BookingModalForm/container.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { selectBooking, updateEventDuration } from '../../../actions/dashboard';
 import {
+  validationMessage,
   checkIfPastDatesSelected,
   checkIfDatesFallOnWeekend,
   checkIfSelectedDatesOverlapExisting,
@@ -65,9 +66,9 @@ const Container = Wrapped =>
       const pastDatesSelected = checkIfPastDatesSelected(start);
       const datesFallOnWeekend = checkIfDatesFallOnWeekend(start, end);
       if (pastDatesSelected) {
-        return 'Unable to select past dates';
+        return validationMessage.PAST_DATES_SELECTED;
       } else if (datesFallOnWeekend) {
-        return 'Unable to select weekend dates';
+        return validationMessage.WEEKEND_DATES_SELECTED;
       } else {
         const {
           userDetails: { employeeId },
@@ -83,9 +84,9 @@ const Container = Wrapped =>
           eventId,
         );
         if (datesOverlapExisting) {
-          return 'You cannot request dates that have already been set';
+          return validationMessage.DATES_ALREADY_REQUESTED;
         } else {
-          return 'Dates approved';
+          return validationMessage.DATES_APPROVED;
         }
       }
     }
@@ -108,7 +109,8 @@ const Container = Wrapped =>
         const calendarValidationResults = this.handleCalendarValidation(
           formData,
         );
-        formIsValid = calendarValidationResults === 'Dates approved';
+        formIsValid =
+          calendarValidationResults === validationMessage.DATES_APPROVED;
         Toast({
           type: formIsValid ? 'success' : 'warning',
           title: calendarValidationResults,

--- a/web-app/src/components/BookingModal/BookingModalForm/index.js
+++ b/web-app/src/components/BookingModal/BookingModalForm/index.js
@@ -27,7 +27,7 @@ const BookingModalForm = props => {
         {
           label: 'Update',
           event: updateEvent,
-          disabled: !formIsValid || bookingDuration === 0,
+          disabled: !formIsValid,
         },
       ];
     } else {
@@ -35,7 +35,7 @@ const BookingModalForm = props => {
         {
           label: 'Request',
           event: createEvent,
-          disabled: !formIsValid || bookingDuration === 0,
+          disabled: !formIsValid,
         },
       ];
     }

--- a/web-app/src/components/common/Input/index.js
+++ b/web-app/src/components/common/Input/index.js
@@ -94,7 +94,17 @@ const Input = props => {
       inputElement = (
         <DatePickerContainer className={inputClasses.join(' ')}>
           <FontAwesomeIcon icon={faCalendarAlt} />
-          <DatePicker selected={value} onChange={changed} />
+          <DatePicker
+            selected={value}
+            onChange={changed}
+            placeholderText={htmlAttrs.placeholder}
+            disabledKeyboardNavigation
+            readOnly
+            filterDate={date => {
+              const day = date.day();
+              return day !== 0 && day !== 6;
+            }}
+          />
         </DatePickerContainer>
       );
       break;

--- a/web-app/src/utilities/dashboardEvents.js
+++ b/web-app/src/utilities/dashboardEvents.js
@@ -1,4 +1,5 @@
 import { getDurationBetweenDates } from './dates';
+import eventTypes from './eventTypes';
 import mandatoryEvents from './mandatoryEvents';
 import flow from 'lodash/fp/flow';
 import moment from 'moment';
@@ -50,6 +51,38 @@ export const getEventDuration = event => {
   }
 };
 
+/*
+  Booking Form Validation
+*/
+
+export const startDateValidation = formData => {
+  if (formData.isHalfday) {
+    formData.end = formData.start;
+  } else {
+    if (formData.start.isAfter(formData.end)) {
+      formData.end = formData.start;
+    }
+  }
+  return formData;
+};
+
+export const endDateValidation = formData => {
+  if (formData.isHalfday) {
+    formData.start = formData.end;
+  } else {
+    if (formData.end.isBefore(formData.start)) {
+      formData.start = formData.end;
+    }
+  }
+  return formData;
+};
+
+export const halfDayValidation = formData => {
+  formData.end = formData.start;
+  formData.eventTypeId = eventTypes.ANNUAL_LEAVE;
+  return formData;
+};
+
 /* 
   Events Validation
 */
@@ -87,26 +120,4 @@ export const checkIfSelectedDatesOverlapExisting = (
     }
   });
   return overlappingEvents.length > 0;
-};
-
-export const validateSelectedDates = (events, employeeId, start, end) => {
-  const pastDatesSelected = checkIfPastDatesSelected(start);
-  const datesFallOnWeekend = checkIfDatesFallOnWeekend(start, end);
-  if (pastDatesSelected) {
-    return 'Unable to select past dates';
-  } else if (datesFallOnWeekend) {
-    return 'Unable to select weekend dates';
-  } else {
-    const datesOverlapExisting = checkIfSelectedDatesOverlapExisting(
-      events,
-      employeeId,
-      start,
-      end,
-    );
-    if (datesOverlapExisting) {
-      return 'You cannot request dates that have already been set';
-    } else {
-      return 'Dates approved';
-    }
-  }
 };

--- a/web-app/src/utilities/dashboardEvents.js
+++ b/web-app/src/utilities/dashboardEvents.js
@@ -49,3 +49,64 @@ export const getEventDuration = event => {
     return duration;
   }
 };
+
+/* 
+  Events Validation
+*/
+
+export const checkIfPastDatesSelected = start => {
+  const today = new moment();
+  return moment(start).isBefore(today);
+};
+
+export const checkIfDatesFallOnWeekend = (start, end) => {
+  if (moment(start).isoWeekday() > 5 && moment(end).isoWeekday() > 5) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export const checkIfSelectedDatesOverlapExisting = (
+  events,
+  employeeId,
+  start,
+  end,
+) => {
+  const overlappingEvents = events.filter(event => {
+    const { employee } = event;
+    if (employee && employee.employeeId === employeeId) {
+      var selectedDateRange = moment.range(
+        moment(start),
+        moment(end).endOf('day'),
+      );
+      var existingEvent = moment.range(moment(event.start), moment(event.end));
+      if (selectedDateRange.overlaps(existingEvent)) {
+        return true;
+      }
+    }
+  });
+  return overlappingEvents.length > 0;
+};
+
+export const validateSelectedDates = (events, employeeId, start, end) => {
+  const pastDatesSelected = checkIfPastDatesSelected(start);
+  const datesFallOnWeekend = checkIfDatesFallOnWeekend(start, end);
+  if (pastDatesSelected) {
+    return 'Unable to select past dates';
+  } else if (datesFallOnWeekend) {
+    return 'Unable to select weekend dates';
+  } else {
+    const datesOverlapExisting = checkIfSelectedDatesOverlapExisting(
+      events,
+      employeeId,
+      start,
+      end,
+    );
+    if (datesOverlapExisting) {
+      return 'You cannot request dates that have already been set';
+    } else {
+      return 'Dates approved';
+    }
+  }
+};

--- a/web-app/src/utilities/dashboardEvents.js
+++ b/web-app/src/utilities/dashboardEvents.js
@@ -87,6 +87,14 @@ export const halfDayValidation = formData => {
   Events Validation
 */
 
+export const validationMessage = {
+  PAST_DATES_SELECTED: 'Unable to select past dates',
+  WEEKEND_DATES_SELECTED: 'Unable to select weekend dates',
+  DATES_ALREADY_REQUESTED:
+    'You cannot request dates that have already been set',
+  DATES_APPROVED: 'Dates approved',
+};
+
 export const checkIfPastDatesSelected = start => {
   const today = new moment();
   return moment(start).isBefore(today);

--- a/web-app/src/utilities/dashboardEvents.js
+++ b/web-app/src/utilities/dashboardEvents.js
@@ -105,10 +105,15 @@ export const checkIfSelectedDatesOverlapExisting = (
   employeeId,
   start,
   end,
+  selectedEventId = null,
 ) => {
   const overlappingEvents = events.filter(event => {
-    const { employee } = event;
-    if (employee && employee.employeeId === employeeId) {
+    const { employee, eventId } = event;
+    if (
+      employee &&
+      employee.employeeId === employeeId &&
+      selectedEventId !== eventId
+    ) {
       var selectedDateRange = moment.range(
         moment(start),
         moment(end).endOf('day'),

--- a/web-app/src/utilities/dashboardEvents.js
+++ b/web-app/src/utilities/dashboardEvents.js
@@ -114,11 +114,14 @@ export const checkIfSelectedDatesOverlapExisting = (
       employee.employeeId === employeeId &&
       selectedEventId !== eventId
     ) {
-      var selectedDateRange = moment.range(
+      const selectedDateRange = moment.range(
         moment(start),
         moment(end).endOf('day'),
       );
-      var existingEvent = moment.range(moment(event.start), moment(event.end));
+      const existingEvent = moment.range(
+        moment(event.start),
+        moment(event.end),
+      );
       if (selectedDateRange.overlaps(existingEvent)) {
         return true;
       }


### PR DESCRIPTION
All validation calls have been moved to dashboardEvents utility where they can be shared.
The react-datepicker has also been updated to not allow a user to manually add a date to the input field, as well as restrict weekend dates from being selected.

Calendar Dashboard validation now tests for:

**Using the Calendar or Booking Modal**
Prevent a user from selecting:
- A past date
- Weekend only dates
- Dates that collide with dates already booked, not including event if selected
- Other peoples events