### PR TITLE
Fix/ts 46 dash colours

### DIFF
--- a/web-app/src/components/BookingModal/container.js
+++ b/web-app/src/components/BookingModal/container.js
@@ -81,7 +81,7 @@ const Container = Wrapped =>
       const request = {
         endDate: end.format(this.dateFormat),
         halfDay: isHalfday,
-        holidayId: eventId,
+        eventId: eventId,
         startDate: start.format(this.dateFormat),
       };
 

--- a/web-app/src/components/HolidayModal/container.js
+++ b/web-app/src/components/HolidayModal/container.js
@@ -36,9 +36,9 @@ const HolidayModalContainer = Wrapped =>
     }
 
     approveHoliday = () => {
-      const holidayId = this.state.holiday.holidayId;
+      const eventId = this.state.holiday.eventId;
 
-      approveHoliday(holidayId)
+      approveHoliday(eventId)
         .then(() => {
           this.setState({
             holiday: {
@@ -61,9 +61,9 @@ const HolidayModalContainer = Wrapped =>
     };
 
     rejectHoliday = () => {
-      const holidayId = this.state.holiday.holidayId;
+      const eventId = this.state.holiday.eventId;
 
-      rejectHoliday(holidayId)
+      rejectHoliday(eventId)
         .then(() => {
           this.setState({
             holiday: {

--- a/web-app/src/components/Legend/container.js
+++ b/web-app/src/components/Legend/container.js
@@ -61,16 +61,13 @@ const LegendContainer = Wrapped =>
       const keysFormatted = [];
 
       legendKeys.forEach(key => {
-        // dont wish to show annual leave as its really part of holiday status
-        if (key !== 'ANNUAL_LEAVE') {
-          keysFormatted.push({
-            id: key,
-            status: eventTypes[key],
-            text: typeText[eventTypes[key]],
-            icon: typeIcons[eventTypes[key]],
-            active: false,
-          });
-        }
+        keysFormatted.push({
+          id: key,
+          status: eventTypes[key],
+          text: typeText[eventTypes[key]],
+          icon: typeIcons[eventTypes[key]],
+          active: false,
+        });
       });
 
       this.setState({ legendKeyTypes: keysFormatted });
@@ -93,7 +90,7 @@ const LegendContainer = Wrapped =>
 
         this.props.updateCalendarEvents(
           eventCategory.HOLIDAY_STATUS,
-          activeKeyIds,
+          activeKeyIds
         );
       });
     };
@@ -128,17 +125,13 @@ const LegendContainer = Wrapped =>
         },
         () => {
           this.props.updateEmployee(this.state.selectedEmployee.employeeId);
-        },
+        }
       );
     };
 
     getEmployeeState = () => {
       const { allEvents } = this.props;
-      return flow(
-        map('employee'),
-        compact,
-        uniqBy('employeeId'),
-      )(allEvents);
+      return flow(map('employee'), compact, uniqBy('employeeId'))(allEvents);
     };
 
     render() {
@@ -164,7 +157,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default compose(
-  connect(mapStateToProps),
-  LegendContainer,
-);
+export default compose(connect(mapStateToProps), LegendContainer);

--- a/web-app/src/components/common/Event/index.js
+++ b/web-app/src/components/common/Event/index.js
@@ -9,16 +9,18 @@ import moment from 'moment';
 const Event = ({ children, event }) => {
   const { eventStatusId } = event.eventStatus;
   const { eventTypeId } = event.eventType;
-  let id = eventTypeId;
+  let id;
   let icon;
   let category;
 
   if (eventTypeId === eventTypes.ANNUAL_LEAVE) {
     icon = statusIcons[eventStatusId];
     category = eventCategory.HOLIDAY_STATUS;
+    id = eventStatusId;
   } else {
     icon = typeIcons[eventTypeId];
     category = eventCategory.EVENT_TYPE;
+    id = eventTypeId;
   }
 
   const today = new moment();

--- a/web-app/src/services/holidayService.js
+++ b/web-app/src/services/holidayService.js
@@ -20,10 +20,10 @@ export const updateHoliday = holiday => {
   return axios.put('/holidays/', holiday);
 };
 
-export const approveHoliday = holidayId => {
-  return axios.put('/holidays/approveHoliday', { holidayId });
+export const approveHoliday = eventId => {
+  return axios.put('/holidays/approveHoliday', { eventId });
 };
 
-export const rejectHoliday = holidayId => {
-  return axios.put('/holidays/cancelHoliday', { holidayId });
+export const rejectHoliday = eventId => {
+  return axios.put('/holidays/rejectHoliday', { eventId });
 };

--- a/web-app/src/styled.js
+++ b/web-app/src/styled.js
@@ -45,11 +45,12 @@ export const theme = {
     [holidayStatus.PENDING]: '#ff9b34',
     [holidayStatus.REJECTED]: '#ff3434',
     [holidayStatus.APPROVED]: '#35c375',
+    [holidayStatus.CANCELLED]: '#232323',
     [holidayStatus.MANDATORY]: '#0eb5d1',
     [holidayStatus.WFH]: '#3469ff',
   },
   eventType: {
-    [eventTypes.ANNUAL_LEAVE]: '#35c375',
+    [eventTypes.ANNUAL_LEAVE]: '#5ccc4b',
     [eventTypes.WFH]: '#3469ff',
   },
 };

--- a/web-app/src/utilities/eventTypes.js
+++ b/web-app/src/utilities/eventTypes.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import { faThumbsUp, faHome } from '@fortawesome/fontawesome-free-solid';
+import { faCalendar, faHome } from '@fortawesome/fontawesome-free-solid';
 
 export default {
   ANNUAL_LEAVE: 1,
@@ -11,6 +11,6 @@ export const typeText = [null, 'Annual leave', 'Working remotely'];
 
 export const typeIcons = [
   null,
-  <FontAwesomeIcon icon={faThumbsUp} />,
+  <FontAwesomeIcon icon={faCalendar} />,
   <FontAwesomeIcon icon={faHome} />,
 ];

--- a/web-app/src/utilities/holidayStatus.js
+++ b/web-app/src/utilities/holidayStatus.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import {
-  faThumbsUp,
-  faThumbsDown,
   faClock,
   faSun,
+  faCalendarTimes,
+  faCalendarCheck,
 } from '@fortawesome/fontawesome-free-solid';
 
 export default {
   PENDING: 1,
   APPROVED: 2,
   REJECTED: 3,
-  MANDATORY: 4,
+  CANCELLED: 4,
+  MANDATORY: 5,
 };
 
 export const statusText = [
@@ -19,13 +20,15 @@ export const statusText = [
   'Pending',
   'Approved',
   'Rejected',
+  'Cancelled',
   'Mandatory',
 ];
 
 export const statusIcons = [
   null,
   <FontAwesomeIcon icon={faClock} />,
-  <FontAwesomeIcon icon={faThumbsUp} />,
-  <FontAwesomeIcon icon={faThumbsDown} />,
+  <FontAwesomeIcon icon={faCalendarCheck} />,
+  <FontAwesomeIcon icon={faCalendarTimes} />,
+  <FontAwesomeIcon icon={faCalendarTimes} />,
   <FontAwesomeIcon icon={faSun} />,
 ];


### PR DESCRIPTION
Relies on back-end from TS-31 (#212)

- Fixes issue with event background colours not matching up with statuses
- Fixes additional issues where events couldn't be created or updated because back-end now expects `eventId` in the request instead of `holidayId`.
- Adds "Annual Leave" type to filtering, in case you don't want to see working from home events.
- Updated icons