### PR TITLE
[TS-42] Fix loading overlay causing flicker on fast connections

### DIFF
--- a/web-app/src/actions/dashboard.js
+++ b/web-app/src/actions/dashboard.js
@@ -1,7 +1,7 @@
 import * as actionTypes from '../actionTypes';
 import { getUsersEvents, getTeamsEvents } from '../services/dashboardService';
 import eventsView from '../utilities/eventsView';
-import { setLoading } from './loading';
+import { setLoadingAsync } from './loading';
 
 import {
   getEventDuration,
@@ -73,9 +73,9 @@ export const fetchEvents = (date, eventView, force = false) => dispatch => {
 
     setTimeout(() => {
       if (shouldBeLoading) {
-        dispatch(setLoading(true));
+        dispatch(setLoadingAsync(true));
       }
-    }, 1000);
+    }, 500);
 
     // If force is true, we need a clean slate. Wipe all events.
     if (force) {
@@ -85,7 +85,7 @@ export const fetchEvents = (date, eventView, force = false) => dispatch => {
     // Set up a function that will run on success.
     const onSuccess = data => {
       shouldBeLoading = false;
-      dispatch(setLoading(false));
+      dispatch(setLoadingAsync(false));
       transformEvents(data).then(transformedEvents => {
         dispatch(setCalendarEvents(transformedEvents));
       });
@@ -95,7 +95,7 @@ export const fetchEvents = (date, eventView, force = false) => dispatch => {
 
     const onError = error => {
       shouldBeLoading = false;
-      dispatch(setLoading(false));
+      dispatch(setLoadingAsync(false));
       dispatch(setError(error));
     };
 

--- a/web-app/src/actions/dashboard.js
+++ b/web-app/src/actions/dashboard.js
@@ -67,8 +67,15 @@ export const setEventView = eventView => {
 export const fetchEvents = (date, eventView, force = false) => dispatch => {
   // Check if we need to make a request (is there existing state?)
   if (requiresNewRequest(date) || force) {
-    // Start loading
-    dispatch(setLoading(true));
+    // Setup for loading indicator. Only show indicator if been loading for more
+    // than a second.
+    let shouldBeLoading = true;
+
+    setTimeout(() => {
+      if (shouldBeLoading) {
+        dispatch(setLoading(true));
+      }
+    }, 1000);
 
     // If force is true, we need a clean slate. Wipe all events.
     if (force) {
@@ -77,6 +84,7 @@ export const fetchEvents = (date, eventView, force = false) => dispatch => {
 
     // Set up a function that will run on success.
     const onSuccess = data => {
+      shouldBeLoading = false;
       dispatch(setLoading(false));
       transformEvents(data).then(transformedEvents => {
         dispatch(setCalendarEvents(transformedEvents));
@@ -86,6 +94,7 @@ export const fetchEvents = (date, eventView, force = false) => dispatch => {
     // Set up a function that will run on fail.
 
     const onError = error => {
+      shouldBeLoading = false;
       dispatch(setLoading(false));
       dispatch(setError(error));
     };

--- a/web-app/src/actions/loading.js
+++ b/web-app/src/actions/loading.js
@@ -1,8 +1,32 @@
+import moment from 'moment';
+import { loadingSince } from '../reducers';
 import { SET_LOADING } from '../actionTypes';
+import store from '../store';
 
 export function setLoading(isLoading) {
   return {
     type: SET_LOADING,
-    payload: isLoading,
+    payload: { isLoading, startedAt: isLoading ? new moment() : null },
   };
 }
+
+// Set loading async is responsible for making sure if the loading indicator
+// does show, that it will show up for at least 1s.
+export const setLoadingAsync = isLoading => dispatch => {
+  let minimumLoadingTime = 1000;
+  const loadingSinceMoment = loadingSince(store.getState());
+
+  if (!isLoading && loadingSinceMoment) {
+    const now = new moment();
+    const millisecondsLoading = now.diff(loadingSinceMoment, 'milliseconds');
+    if (millisecondsLoading >= minimumLoadingTime) {
+      dispatch(setLoading(isLoading));
+    } else {
+      setTimeout(() => {
+        dispatch(setLoading(isLoading));
+      }, minimumLoadingTime - millisecondsLoading);
+    }
+  } else {
+    dispatch(setLoading(isLoading));
+  }
+};

--- a/web-app/src/reducers/index.js
+++ b/web-app/src/reducers/index.js
@@ -40,3 +40,4 @@ export const getBookingDuration = store =>
 
 //Loading
 export const isLoading = store => FromLoading.isLoading(store[LOADING]);
+export const loadingSince = store => FromLoading.loadingSince(store[LOADING]);

--- a/web-app/src/reducers/loading.js
+++ b/web-app/src/reducers/loading.js
@@ -2,6 +2,7 @@ import { SET_LOADING } from '../actionTypes';
 
 export const initialState = {
   loading: false,
+  startedAt: null,
 };
 
 // Reducer
@@ -14,9 +15,11 @@ export default function loadingReducer(state = initialState, action) {
 const ACTION_HANDLERS = {
   [SET_LOADING]: (state, action) => ({
     ...state,
-    loading: action.payload,
+    loading: action.payload.isLoading,
+    startedAt: action.payload.startedAt,
   }),
 };
 
 // Private Selectors
 export const isLoading = store => store.loading;
+export const loadingSince = store => store.startedAt;


### PR DESCRIPTION
If you had a fast connection and data loaded really fast, the loading overlay would create what looked like a page flicker.

Now the indicator only displays if the user has been waiting for data for more than 1 second. This means slow connections will still see the indicator but fast ones will have data come in smoothly creating a nicer experience.