### PR TITLE
[TS-53] Stop overlapping and responsive styling for event type toggle

### DIFF
--- a/web-app/src/components/common/ToggleButton/index.js
+++ b/web-app/src/components/common/ToggleButton/index.js
@@ -14,8 +14,8 @@ const ToggleButton = props => {
             onClick={onToggleButton}
             className={activeButtonText === button.text ? 'active' : ''}
           >
-            <span>{button.icon}</span>
-            <span className="btnText">{button.text}</span>
+            <span className="btn-icon">{button.icon}</span>
+            <span className="btn-text">{button.text}</span>
           </button>
         );
       })}

--- a/web-app/src/components/common/ToggleButton/index.js
+++ b/web-app/src/components/common/ToggleButton/index.js
@@ -15,7 +15,7 @@ const ToggleButton = props => {
             className={activeButtonText === button.text ? 'active' : ''}
           >
             <span>{button.icon}</span>
-            <span>{button.text}</span>
+            <span className="btnText">{button.text}</span>
           </button>
         );
       })}

--- a/web-app/src/pages/Dashboard/styled.js
+++ b/web-app/src/pages/Dashboard/styled.js
@@ -2,11 +2,31 @@ import styled from 'styled-components';
 
 export const ButtonToggle = styled.div`
   position: absolute;
-  left: calc(60% - 111px);
+  right: 350px;
   top: 30px;
-  display: flex;
   height: 40px;
-   `;
+  display: none;
+  .btnText {
+    display: none;
+  }
+
+  span {
+    margin: 0 !important;
+  }
+
+  @media (min-width: ${props => props.theme.mediaQueries.lg}) {
+    .btnText {
+      display: inline;
+    }
+    span {
+      margin: inherit;
+    }
+  }
+
+  @media (min-width: ${props => props.theme.mediaQueries.md}) {
+    display: flex;
+  }
+`;
 
 export const InnerLayout = styled.div`
   width: 100%;

--- a/web-app/src/pages/Dashboard/styled.js
+++ b/web-app/src/pages/Dashboard/styled.js
@@ -6,25 +6,24 @@ export const ButtonToggle = styled.div`
   top: 30px;
   height: 40px;
   display: none;
-  .btnText {
+  .btn-text {
     display: none;
-  }
-
-  span {
-    margin: 0 !important;
-  }
-
-  @media (min-width: ${props => props.theme.mediaQueries.lg}) {
-    .btnText {
-      display: inline;
-    }
-    span {
-      margin: inherit;
-    }
   }
 
   @media (min-width: ${props => props.theme.mediaQueries.md}) {
     display: flex;
+    .btn-icon {
+      margin-right: 0px;
+    }
+  }
+
+  @media (min-width: ${props => props.theme.mediaQueries.lg}) {
+    .btn-text {
+      display: inline;
+    }
+    .btn-icon {
+      margin-right: 6px;
+    }
   }
 `;
 


### PR DESCRIPTION
- Fixes overlapping of event type toggle & calendar navigation buttons.
- Improves responsiveness of event type toggle.

![chrome_2018-09-11_16-36-11](https://user-images.githubusercontent.com/39301552/45370804-e5f2da80-b5e0-11e8-94d7-6fc75203baf2.png)

![chrome_2018-09-11_16-36-19](https://user-images.githubusercontent.com/39301552/45370805-e8553480-b5e0-11e8-947b-60c5095f14fd.png)

![chrome_2018-09-11_16-36-28](https://user-images.githubusercontent.com/39301552/45370806-e9866180-b5e0-11e8-90c1-a6b46de98107.png)
