### PR TITLE
[TS-67] Fix ability to cancel holidays by calling correct endpoint.

### DIFF
--- a/web-app/src/components/BookingModal/ModalStatusBanner/index.jsx
+++ b/web-app/src/components/BookingModal/ModalStatusBanner/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
 import { Banner } from './styled';
 import eventCategory from '../../../utilities/eventCategory';
@@ -7,39 +7,61 @@ import eventTypes, { typeText } from '../../../utilities/eventTypes';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/fontawesome-free-solid';
 
-const ModalStatusBanner = props => {
-  const { userName, eventStatus, eventType, cancelEvent } = props;
-  const { eventStatusId } = eventStatus;
-  const { eventTypeId } = eventType;
-
-  let bannerId;
-  let bannerDescription;
-  let category;
-  if (eventTypeId === eventTypes.ANNUAL_LEAVE) {
-    bannerId = eventStatusId;
-    bannerDescription = statusText[eventStatusId];
-    category = eventCategory.HOLIDAY_STATUS;
-  } else {
-    bannerId = eventTypeId;
-    bannerDescription = typeText[eventTypeId];
-    category = eventCategory.EVENT_TYPE;
+class ModalStatusBanner extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      cancelConfirm: false,
+    };
   }
 
-  return (
-    <Banner status={bannerId} className={category}>
-      <div>
-        <h4>{userName}</h4>
-        <p>{bannerDescription}</p>
-      </div>
-      <div>
-        <div className="cancelEvent" onClick={cancelEvent}>
-          <FontAwesomeIcon icon={faTrash} />
-          <span>Cancel Event</span>
+  handleCancel = event => {
+    if (!this.state.cancelConfirm) {
+      this.setState({ cancelConfirm: true });
+    } else {
+      this.props.cancelEvent(event);
+    }
+  };
+
+  render() {
+    const {
+      userName,
+      eventStatus: { eventStatusId },
+      eventType: { eventTypeId },
+    } = this.props;
+    const { cancelConfirm } = this.state;
+
+    let bannerId;
+    let bannerDescription;
+    let category;
+    if (eventTypeId === eventTypes.ANNUAL_LEAVE) {
+      bannerId = eventStatusId;
+      bannerDescription = statusText[eventStatusId];
+      category = eventCategory.HOLIDAY_STATUS;
+    } else {
+      bannerId = eventTypeId;
+      bannerDescription = typeText[eventTypeId];
+      category = eventCategory.EVENT_TYPE;
+    }
+
+    return (
+      <Banner status={bannerId} className={category}>
+        <div>
+          <h4>{userName}</h4>
+          <p>{bannerDescription}</p>
         </div>
-      </div>
-    </Banner>
-  );
-};
+        <div>
+          <div className="cancelEvent" onClick={this.handleCancel}>
+            <FontAwesomeIcon icon={faTrash} />
+            <span>
+              {cancelConfirm ? 'Confirm? (Click Again)' : 'Cancel Event'}
+            </span>
+          </div>
+        </div>
+      </Banner>
+    );
+  }
+}
 
 ModalStatusBanner.propTypes = {
   userName: PT.string.isRequired,

--- a/web-app/src/components/BookingModal/ModalStatusBanner/index.jsx
+++ b/web-app/src/components/BookingModal/ModalStatusBanner/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { PropTypes as PT } from 'prop-types';
 import { Banner } from './styled';
 import eventCategory from '../../../utilities/eventCategory';
-import { statusText } from '../../../utilities/holidayStatus';
+import holidayStatus, { statusText } from '../../../utilities/holidayStatus';
 import eventTypes, { typeText } from '../../../utilities/eventTypes';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/fontawesome-free-solid';
@@ -31,6 +31,7 @@ class ModalStatusBanner extends Component {
     } = this.props;
     const { cancelConfirm } = this.state;
 
+    let isCancelled = eventStatusId === holidayStatus.CANCELLED;
     let bannerId;
     let bannerDescription;
     let category;
@@ -51,12 +52,14 @@ class ModalStatusBanner extends Component {
           <p>{bannerDescription}</p>
         </div>
         <div>
-          <div className="cancelEvent" onClick={this.handleCancel}>
-            <FontAwesomeIcon icon={faTrash} />
-            <span>
-              {cancelConfirm ? 'Confirm? (Click Again)' : 'Cancel Event'}
-            </span>
-          </div>
+          {!isCancelled && (
+            <div className="cancelEvent" onClick={this.handleCancel}>
+              <FontAwesomeIcon icon={faTrash} />
+              <span>
+                {cancelConfirm ? 'Confirm? (Click Again)' : 'Cancel Event'}
+              </span>
+            </div>
+          )}
         </div>
       </Banner>
     );

--- a/web-app/src/components/BookingModal/container.js
+++ b/web-app/src/components/BookingModal/container.js
@@ -12,7 +12,7 @@ import {
 import {
   updateHoliday,
   requestHoliday,
-  rejectHoliday,
+  cancelHoliday,
 } from '../../services/holidayService';
 import { requestWFH } from '../../services/wfhService';
 import eventTypes from '../../utilities/eventTypes';
@@ -108,7 +108,7 @@ const Container = Wrapped =>
         toggleBookingModal,
         booking: { eventId },
       } = this.props;
-      rejectHoliday(eventId)
+      cancelHoliday(eventId)
         .then(() => {
           updateTakenEvents();
           toggleBookingModal(false);

--- a/web-app/src/services/holidayService.js
+++ b/web-app/src/services/holidayService.js
@@ -27,3 +27,7 @@ export const approveHoliday = eventId => {
 export const rejectHoliday = eventId => {
   return axios.put('/holidays/rejectHoliday', { eventId });
 };
+
+export const cancelHoliday = eventId => {
+  return axios.put('/holidays/cancelHoliday', { eventId });
+};


### PR DESCRIPTION
Cancelling a holiday now calls the new `cancelHoliday` endpoint. I've added a temporary solution to confirming a holiday cancellation that should be changed later. I didn't want to modify the file too much because Paul is working in the same area of code.