### PR TITLE
[TS-70] Legend now appears on the right of the calendar, instead of below

### DIFF
--- a/web-app/src/components/Legend/index.jsx
+++ b/web-app/src/components/Legend/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes as PT } from 'prop-types';
-import { StyleContainer, Column } from './styled';
+import { StyleContainer } from './styled';
 import container from './container';
 import FilterByKey from './filterByKey';
 import FilterByUser from './filterByUser';
@@ -21,7 +21,7 @@ const Legend = ({
   if (eventView === eventsView.TEAM_EVENTS) {
     filterUser = (
       <div>
-        <h4>Filter by Employee</h4>
+        <h4>Employee</h4>
         <FilterByUser
           selectedEmployee={selectedEmployee}
           employeeList={employeeList}
@@ -33,23 +33,20 @@ const Legend = ({
 
   return (
     <StyleContainer>
-      <Column>{filterUser}</Column>
-      <Column>
-        <h4>Filter by Holiday Status</h4>
-        <FilterByKey
-          category={eventCategory.HOLIDAY_STATUS}
-          keyList={legendKeyStatuses}
-          onToggleEvent={onToggleStatus}
-        />
-      </Column>
-      <Column>
-        <h4>Filter by Event Type</h4>
-        <FilterByKey
-          category={eventCategory.EVENT_TYPE}
-          keyList={legendKeyTypes}
-          onToggleEvent={onToggleType}
-        />
-      </Column>
+      <h3>Calendar Filters</h3>
+      {filterUser}
+      <h4>Holiday Status</h4>
+      <FilterByKey
+        category={eventCategory.HOLIDAY_STATUS}
+        keyList={legendKeyStatuses}
+        onToggleEvent={onToggleStatus}
+      />
+      <h4>Event Type</h4>
+      <FilterByKey
+        category={eventCategory.EVENT_TYPE}
+        keyList={legendKeyTypes}
+        onToggleEvent={onToggleType}
+      />
     </StyleContainer>
   );
 };

--- a/web-app/src/components/Legend/styled.js
+++ b/web-app/src/components/Legend/styled.js
@@ -1,35 +1,24 @@
 import styled from 'styled-components';
 
 export const StyleContainer = styled.div`
+  min-width: 200px;
   box-sizing: border-box;
-  background-color: ${props => props.theme.colours.lightgrey};
-  border: 1px solid ${props => props.theme.colours.grey};
-  border-radius: 0 0 6px 6px;
   border-top: none;
-  width: 100%;
-  padding: 20px 10px 0 10px;
-  display: block;
-  @media (min-width: ${props => props.theme.mediaQueries.xl}) {
-    display: flex;
-  }
+  margin-top: 66px;
 
-  svg {
-    margin-right: 10px;
+  h3 {
+    margin: 0;
   }
-`;
-
-export const Column = styled.div`
-    width: 100%;
-    margin: 10px;
-  }
-
   h4 {
-    width: 100%;
-    margin: 0 0 10px 0;
+    margin: 20px 0 10px 0;
+    :first-of-type {
+      margin: 10px 0 10px 0;
+    }
   }
 `;
 
 export const Key = styled.div`
+  user-select: none;
   box-sizing: border-box;
   background-color: white;
   background-color: ${props => props.theme.holidayStatus[props.status]};
@@ -41,6 +30,11 @@ export const Key = styled.div`
   padding: 8px;
   cursor: pointer;
   transition: all 150ms;
+
+  svg {
+    margin-right: 10px;
+  }
+
   &:hover {
     opacity: 0.9;
   }

--- a/web-app/src/pages/Dashboard/index.jsx
+++ b/web-app/src/pages/Dashboard/index.jsx
@@ -3,7 +3,7 @@ import { PropTypes as PT } from 'prop-types';
 import container from './container';
 import { BookingCalendar, BookingModal, Legend } from '../../components';
 import { ToggleButton } from '../../components/common';
-import { InnerLayout, ButtonToggle } from './styled';
+import { InnerLayout, ButtonToggle, CalendarLayoutContainer } from './styled';
 import eventsView, {
   eventsViewText,
   eventsViewIcons,
@@ -51,17 +51,21 @@ export const Dashboard = props => {
             onToggleButton={onToggleEventsView}
           />
         </ButtonToggle>
-        <BookingCalendar
-          employeeId={employeeId}
-          events={filteredEvents}
-          isEventBeingUpdated={isEventBeingUpdated}
-          onNavigate={onCalendarNavigate}
-        />
-        <Legend
-          updateCalendarEvents={onUpdateEvents}
-          updateEmployee={onUpdateEmployee}
-          allEvents={allEvents}
-        />
+        <CalendarLayoutContainer>
+          <div className="calendar">
+            <BookingCalendar
+              employeeId={employeeId}
+              events={filteredEvents}
+              isEventBeingUpdated={isEventBeingUpdated}
+              onNavigate={onCalendarNavigate}
+            />
+          </div>
+          <Legend
+            updateCalendarEvents={onUpdateEvents}
+            updateEmployee={onUpdateEmployee}
+            allEvents={allEvents}
+          />
+        </CalendarLayoutContainer>
       </InnerLayout>
     </Fragment>
   );

--- a/web-app/src/pages/Dashboard/styled.js
+++ b/web-app/src/pages/Dashboard/styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const ButtonToggle = styled.div`
   position: absolute;
-  right: 350px;
+  right: 575px;
   top: 30px;
   height: 40px;
   display: none;
@@ -32,7 +32,7 @@ export const InnerLayout = styled.div`
   height: 100%;
 
   .rbc-calendar {
-    height: 800px;
+    height: 900px;
   }
 
   .rbc-show-more {
@@ -47,6 +47,23 @@ export const InnerLayout = styled.div`
     &:hover {
       transform: scale(1.05);
       box-shadow: 0px 0px 12px -1px rgba(0, 0, 0, 0.6);
+    }
+  }
+
+  .rbc-month-header {
+    border-radius: 5px 5px 0 0;
+    overflow: hidden;
+  }
+
+  .rbc-month-view {
+    border: none;
+  }
+
+  .rbc-month-row {
+    border-left: 1px solid #ddd;
+    border-right: 1px solid #ddd;
+    :last-of-type {
+      border-bottom: 1px solid #ddd;
     }
   }
 
@@ -76,5 +93,14 @@ export const InnerLayout = styled.div`
 
   .rbc-today {
     background-color: ${props => props.theme.colours.lightBlue};
+  }
+`;
+
+export const CalendarLayoutContainer = styled.div`
+  display: flex;
+
+  .calendar {
+    flex-grow: 1;
+    margin-right: 20px;
   }
 `;

--- a/web-app/src/pages/Dashboard/styled.js
+++ b/web-app/src/pages/Dashboard/styled.js
@@ -10,14 +10,14 @@ export const ButtonToggle = styled.div`
     display: none;
   }
 
-  @media (min-width: ${props => props.theme.mediaQueries.md}) {
+  @media (min-width: ${props => props.theme.mediaQueries.lg}) {
     display: flex;
     .btn-icon {
       margin-right: 0px;
     }
   }
 
-  @media (min-width: ${props => props.theme.mediaQueries.lg}) {
+  @media (min-width: ${props => props.theme.mediaQueries.xl}) {
     .btn-text {
       display: inline;
     }

--- a/web-app/src/pages/Dashboard/styled.js
+++ b/web-app/src/pages/Dashboard/styled.js
@@ -60,10 +60,10 @@ export const InnerLayout = styled.div`
   }
 
   .rbc-month-row {
-    border-left: 1px solid #ddd;
-    border-right: 1px solid #ddd;
+    border-left: 1px solid ${props => props.theme.colours.borderGrey};
+    border-right: 1px solid ${props => props.theme.colours.borderGrey};
     :last-of-type {
-      border-bottom: 1px solid #ddd;
+      border-bottom: 1px solid ${props => props.theme.colours.borderGrey};
     }
   }
 

--- a/web-app/src/styled.js
+++ b/web-app/src/styled.js
@@ -12,6 +12,7 @@ export const theme = {
     lightgrey: '#f7f7f7',
     darkGrey: '#3a3939',
     lightRed: '#fda49a',
+    borderGrey: '#dddddd',
     red: '#ff3434',
     darkRed: '#c4412b',
     green: '#35c375',


### PR DESCRIPTION
I made this change for a few reasons:
- It removes the need to scroll up and down the page to interact with the filters.
- This layout makes better use of space. Previously keys would have appeared really wide for no reason.
- Allows for the calendar to have more height and therefore fit more events in view.

![chrome_2018-09-17_14-07-27](https://user-images.githubusercontent.com/39301552/45624716-0b6d6180-ba83-11e8-8165-8e8abd9b4f47.png)
