### PR TITLE
Add next year's mandatory events to calendar

### DIFF
--- a/web-app/src/utilities/mandatoryEvents.js
+++ b/web-app/src/utilities/mandatoryEvents.js
@@ -17,6 +17,18 @@ const mandatoryEvents = [
     title: 'Memorial Day',
     mandatoryDate: `${currYear}-05-28`,
   },
+  {
+    title: 'Christmas Day',
+    mandatoryDate: `${currYear + 1}-12-25`,
+  },
+  {
+    title: 'New Years Day',
+    mandatoryDate: `${currYear + 1}-12-31`,
+  },
+  {
+    title: 'Memorial Day',
+    mandatoryDate: `${currYear + 1}-05-28`,
+  },
 ];
 
 export default mandatoryEvents.map(event => {


### PR DESCRIPTION
To resolve the issue of mandatory events not showing for the next year, there are now 3 more mandatory events generated for the year after the current.