### PR TITLE
Fixed failing unit test, returned object type was incorrect.

### DIFF
--- a/v2/AdminCore.WebApi.Tests/Controllers/BaseControllerTest.cs
+++ b/v2/AdminCore.WebApi.Tests/Controllers/BaseControllerTest.cs
@@ -37,7 +37,7 @@ namespace AdminCore.WebApi.Tests.Controllers
       switch (expectedStatus)
       {
         case HttpStatusCode.OK:
-          Assert.IsType<OkResult>(result);
+          Assert.IsType<OkObjectResult>(result);
           break;
 
         case HttpStatusCode.NotFound:


### PR DESCRIPTION
Test name: RegisterWithUnregisteredEmailAddress_WhenCalled_ReturnsSuccessfullyRegistered