### PR TITLE
Add missing data to GetByDateBetween

### DIFF
--- a/v2/AdminCore.Common/Interfaces/IEventService.cs
+++ b/v2/AdminCore.Common/Interfaces/IEventService.cs
@@ -9,7 +9,7 @@ namespace AdminCore.Common.Interfaces
   {
     IList<EventDto> GetAnnualLeaveByEmployee(int employeeId);
 
-    IList<EventDto> GetByDateBetween(DateTime startDate, DateTime endDate);
+    IList<EventDto> GetByDateBetween(DateTime startDate, DateTime endDate, EventTypes eventType);
 
     IList<EventDto> GetEventsByEmployeeId(int employeeId, EventTypes eventType);
 

--- a/v2/AdminCore.Services/EventService.cs
+++ b/v2/AdminCore.Services/EventService.cs
@@ -34,23 +34,13 @@ namespace AdminCore.Services
       return _mapper.Map<IList<EventDto>>(annualLeave);
     }
 
-    public IList<EventDto> GetByDateBetween(DateTime startDate, DateTime endDate)
+    public IList<EventDto> GetByDateBetween(DateTime startDate, DateTime endDate, EventTypes eventType)
     {
-      var eventsBetweenDates = DatabaseContext.EventDatesRepository.Get(x => x.StartDate >= startDate
-                                                                             && x.EndDate <= endDate
-                                                                             && x.Event.EventTypeId ==
-                                                                             AnnualLeaveId);
+      int eventTypeId = (int)eventType;
+      var eventsBetweenDates = DatabaseContext.EventDatesRepository.GetAsQueryable(RetrieveEventsWithinRange(startDate, endDate))
+        .Where(x => x.Event.EventTypeId == eventTypeId);
 
-      var events = DatabaseContext.EventRepository.Get(x => eventsBetweenDates.First().StartDate >= startDate
-                                                            && eventsBetweenDates.Last().EndDate <= endDate
-                                                            && x.EventTypeId == AnnualLeaveId,
-                                                            null,
-                                                            x => x.EventDates,
-                                                            x => x.Employee,
-                                                            x => x.EventType,
-                                                            x => x.EventStatus);
-
-      return _mapper.Map<IList<EventDto>>(events);
+      return _mapper.Map<IList<EventDto>>(eventsBetweenDates);
     }
 
     public IList<EventDto> GetEventsByEmployeeId(int employeeId, EventTypes eventType)

--- a/v2/AdminCore.Services/EventService.cs
+++ b/v2/AdminCore.Services/EventService.cs
@@ -40,7 +40,17 @@ namespace AdminCore.Services
                                                                              && x.EndDate <= endDate
                                                                              && x.Event.EventTypeId ==
                                                                              AnnualLeaveId);
-      return _mapper.Map<IList<EventDto>>(eventsBetweenDates);
+
+      var events = DatabaseContext.EventRepository.Get(x => eventsBetweenDates.First().StartDate >= startDate
+                                                            && eventsBetweenDates.Last().EndDate <= endDate
+                                                            && x.EventTypeId == AnnualLeaveId,
+                                                            null,
+                                                            x => x.EventDates,
+                                                            x => x.Employee,
+                                                            x => x.EventType,
+                                                            x => x.EventStatus);
+
+      return _mapper.Map<IList<EventDto>>(events);
     }
 
     public IList<EventDto> GetEventsByEmployeeId(int employeeId, EventTypes eventType)

--- a/v2/AdminCore.WebApi.Tests/Controllers/HolidayControllerTests.cs
+++ b/v2/AdminCore.WebApi.Tests/Controllers/HolidayControllerTests.cs
@@ -143,14 +143,14 @@ namespace AdminCore.WebApi.Tests.Controllers
       const int numOfHolidays = 9;
       var holidayEvents = _fixture.CreateMany<EventDto>(numOfHolidays).ToList();
 
-      _eventService.GetByDateBetween(startDate, endDate).Returns(holidayEvents);
+      _eventService.GetByDateBetween(startDate, endDate, EventTypes.AnnualLeave).Returns(holidayEvents);
       _mapper.Map<List<HolidayViewModel>>(holidayEvents);
 
       // Act
       var result = _controller.GetHolidayByDateBetween(startDate.ToString(), endDate.ToString());
 
       // Assert
-      _eventService.Received(1).GetByDateBetween(Arg.Any<DateTime>(), Arg.Any<DateTime>());
+      _eventService.Received(1).GetByDateBetween(Arg.Any<DateTime>(), Arg.Any<DateTime>(), EventTypes.AnnualLeave);
       var returnedHolidayEvents = RetrieveValueFromActionResult<List<HolidayViewModel>>(result);
       Assert.Equal(numOfHolidays, returnedHolidayEvents.Count);
     }

--- a/v2/AdminCore.WebApp/Controllers/HolidayController.cs
+++ b/v2/AdminCore.WebApp/Controllers/HolidayController.cs
@@ -193,7 +193,7 @@ namespace AdminCore.WebApi.Controllers
 
     private IList<HolidayViewModel> GetEventsBetweenDates(string startDate, string endDate)
     {
-      var holidays = _eventService.GetByDateBetween(Convert.ToDateTime(startDate), Convert.ToDateTime(endDate));
+      var holidays = _eventService.GetByDateBetween(Convert.ToDateTime(startDate), Convert.ToDateTime(endDate), EventTypes.AnnualLeave);
       return _mapper.Map<IList<HolidayViewModel>>(holidays);
     }
   }


### PR DESCRIPTION
Wrote a query to return EventDates then used the result to query the event table.

When attempting to do in one EventRepository query with x.EventDates.First() threw nullable exception